### PR TITLE
Fixed stdout for the shell

### DIFF
--- a/examples/wapm-shell/services/command-runner/command.ts
+++ b/examples/wapm-shell/services/command-runner/command.ts
@@ -19,7 +19,10 @@ export class Command {
   run() {
     throw new Error("Not implemented");
   }
-  instantiate(pipedStdinData?: Uint8Array): Promise<Duplex> | Duplex {
+  instantiate(
+    stdoutCallback?: Function,
+    pipedStdinData?: Uint8Array
+  ): Promise<Duplex> | Duplex {
     throw new Error("Not implemented");
   }
   getStdout(): string {

--- a/examples/wapm-shell/services/process/process.ts
+++ b/examples/wapm-shell/services/process/process.ts
@@ -54,11 +54,10 @@ export default class Process {
   }
 
   async start(pipedStdinData?: Uint8Array) {
-    const commandStream = await this.wasiCommand.instantiate(pipedStdinData);
-
-    commandStream.on("data", (data: any) => {
-      this.dataCallback(data);
-    });
+    const commandStream = await this.wasiCommand.instantiate(
+      this.dataCallback,
+      pipedStdinData
+    );
 
     commandStream.on("end", () => {
       this.endCallback();


### PR DESCRIPTION
Simple fix! 😄 🎉 

This just overrides the `.write` for the stdout file descriptor, and outputs directly to stdout.

Also, this fixes not being prompted twice 🔥 

# Workers

![Screen Shot 2019-08-05 at 5 48 28 PM](https://user-images.githubusercontent.com/1448289/62503676-1966c680-b7aa-11e9-9ffa-00466d082bc7.png)

# Fallback

![Screen Shot 2019-08-05 at 5 49 00 PM](https://user-images.githubusercontent.com/1448289/62503677-1966c680-b7aa-11e9-9993-bce4e0411e12.png)