### PR TITLE
Fixed prompt having generic output

### DIFF
--- a/examples/wapm-shell/services/process/wasi-command.ts
+++ b/examples/wapm-shell/services/process/wasi-command.ts
@@ -33,6 +33,7 @@ export default class WASICommand extends Command {
   stdinReadCounter: number;
   pipedStdin: string;
 
+  stdoutLog: string;
   stdoutCallback?: Function;
 
   constructor(
@@ -57,6 +58,8 @@ export default class WASICommand extends Command {
     }
     this.stdinReadCounter = 0;
     this.pipedStdin = "";
+
+    this.stdoutLog = "";
 
     this.wasi = new WASI({
       // preopenDirectories: {},
@@ -114,6 +117,10 @@ export default class WASICommand extends Command {
       this.stdoutCallback(stdoutBuffer);
     }
 
+    // Record all of our stdout to show in the prompt
+    let dataString = new TextDecoder("utf-8").decode(stdoutBuffer);
+    this.stdoutLog += dataString;
+
     return stdoutBuffer.length;
   }
 
@@ -161,7 +168,11 @@ export default class WASICommand extends Command {
 
       responseStdin = new TextDecoder("utf-8").decode(newStdinData);
     } else {
-      responseStdin = prompt("Stdin");
+      responseStdin = prompt(
+        this.stdoutLog.length > 0
+          ? this.stdoutLog
+          : "Please enter text for stdin:"
+      );
     }
 
     // First check for errors


### PR DESCRIPTION
closes #15 

Now will show all of the stdout of the process up to that point, with a fallback if there is no stdout 😄 

# Examples

<img width="1275" alt="Screen Shot 2019-08-27 at 6 02 30 PM" src="https://user-images.githubusercontent.com/1448289/63818274-3009c480-c8f5-11e9-891d-a5f63449cfd8.png">
<img width="1278" alt="Screen Shot 2019-08-27 at 6 02 44 PM" src="https://user-images.githubusercontent.com/1448289/63818275-3009c480-c8f5-11e9-9000-1d6369e58c97.png">
<img width="1278" alt="Screen Shot 2019-08-27 at 6 02 55 PM" src="https://user-images.githubusercontent.com/1448289/63818276-3009c480-c8f5-11e9-9458-5294e34855aa.png">
<img width="1276" alt="Screen Shot 2019-08-27 at 6 03 02 PM" src="https://user-images.githubusercontent.com/1448289/63818277-30a25b00-c8f5-11e9-96c2-a4313bb61e45.png">
<img width="1278" alt="Screen Shot 2019-08-27 at 6 03 32 PM" src="https://user-images.githubusercontent.com/1448289/63818278-30a25b00-c8f5-11e9-9538-30d0b7100257.png">
<img width="1277" alt="Screen Shot 2019-08-27 at 6 04 09 PM" src="https://user-images.githubusercontent.com/1448289/63818279-30a25b00-c8f5-11e9-8dc5-d53176ebce71.png">