### PR TITLE
Implemented a ton of CTRL Commands and UX

### DIFF
--- a/packages/wasm-terminal/lib/command-runner/command-runner.ts
+++ b/packages/wasm-terminal/lib/command-runner/command-runner.ts
@@ -348,6 +348,8 @@ export default class CommandRunner {
   }
 
   processDataCallback(commandOptionIndex: number, data: Uint8Array) {
+    if (!this.isRunning) return;
+
     if (commandOptionIndex < this.commandOptionsForProcessesToRun.length - 1) {
       // Pass along to the next spawned process
       if (

--- a/packages/wasm-terminal/lib/wasm-tty/wasm-tty.ts
+++ b/packages/wasm-terminal/lib/wasm-tty/wasm-tty.ts
@@ -193,6 +193,20 @@ export default class WasmTTY {
   }
 
   /**
+   * Clears the entire Tty
+   *
+   * This function will erase all the lines that display on the tty,
+   * and move the cursor in the beginning of the first line of the prompt.
+   */
+  clearTty() {
+    // Clear the screen
+    this.xterm.write("\u001b[2J");
+    // Set the cursor to 0, 0
+    this.xterm.write("\u001b[0;0H");
+    this._cursor = 0;
+  }
+
+  /**
    * Function to return if it is the initial read
    */
   getFirstInit(): boolean {


### PR DESCRIPTION
closes #43 
opens #50 

This fixes the broken CTRL+C in Wasm-matrix. It also does a ton of UX commands, such as CTRL+Z, CTRL+J, CTRL+E, etc... And even `!!`. Please see #50 For more info, but the shell is getting better and better! 😄 👍 

**Note: In the gif below, `!!` does not work, but It is fixed and a screenshot is provided**

![wasmShellUx](https://user-images.githubusercontent.com/1448289/64742364-d1297b00-d4b0-11e9-845c-d2d0da5f442d.gif)

<img width="598" alt="Screen Shot 2019-09-11 at 4 21 39 PM" src="https://user-images.githubusercontent.com/1448289/64742377-e1d9f100-d4b0-11e9-912f-092a11288715.png">
