### PR TITLE
Excluded wasmfs tests

### DIFF
--- a/examples/wasm-shell/rollup.config.js
+++ b/examples/wasm-shell/rollup.config.js
@@ -1,4 +1,5 @@
 // Rollup Config for the Wapm Shell Example
+// NOTE: URLs are relative to the project root for this rollup config
 
 import resolve from "rollup-plugin-node-resolve";
 import commonjs from "rollup-plugin-commonjs";

--- a/packages/wasmfs/rollup.config.js
+++ b/packages/wasmfs/rollup.config.js
@@ -17,6 +17,7 @@ const mkdirp = require("mkdirp");
 
 let typescriptPluginOptions = {
   tsconfig: "../../tsconfig.json",
+  exclude: ["./test/**/*"],
   clean: process.env.PROD ? true : false
 };
 


### PR DESCRIPTION
relates to #56 

This simply adds a rollup config to tell typescript to ignore type definitions for the tests when building 😄 I did this for the other packages in #56 But I forgot to do it here.