### PR TITLE
Fixed endCallback when there is no error

### DIFF
--- a/packages/wasm-terminal/lib/command-runner/command-runner.ts
+++ b/packages/wasm-terminal/lib/command-runner/command-runner.ts
@@ -289,11 +289,9 @@ export default class CommandRunner {
   }
 
   _processErrorCallback(commandOptionIndex: number, error: string) {
-    if (this.wasmTty) {
-      this.wasmTty.print(
-        `Program ${this.commandOptionsForProcessesToRun[commandOptionIndex].args[0]}: ${error}\r\n`
-      );
-    }
+    console.error(
+      `${this.commandOptionsForProcessesToRun[commandOptionIndex].args[0]}: ${error}`
+    );
     this.kill();
     this.commandEndCallback();
   }

--- a/packages/wasm-terminal/lib/process/process.ts
+++ b/packages/wasm-terminal/lib/process/process.ts
@@ -69,6 +69,11 @@ export default class Process {
     try {
       this.wasiCommand.run();
     } catch (e) {
+      if (e.code === 0) {
+        // Command was successful, but ended early.
+        this.endCallback();
+        return;
+      }
       let error = "Unknown Error";
 
       if (e.code !== undefined) {


### PR DESCRIPTION
Fixed endCallback when there is no error.

Solving:
* Try to run `echo "a" | lolcat` in the shell
* The exit code is not shown in the terminal (only in the console.error), to mimic how terminals work