### PR TITLE
Fixed the unresponsive prompt state

### DIFF
--- a/packages/wasm-terminal/lib/wasm-shell/wasm-shell.ts
+++ b/packages/wasm-terminal/lib/wasm-shell/wasm-shell.ts
@@ -466,10 +466,11 @@ export default class WasmShell {
 
         case "\x03": // CTRL+C
         case "\x1a": // CTRL+Z
-          this.wasmTty.setCursor(this.wasmTty.getInput().length);
+          const currentInput = this.wasmTty.getInput();
+          this.wasmTty.setCursor(currentInput.length);
           this.wasmTty.setInput("");
           this.wasmTty.setCursorDirectly(0);
-          this.wasmTty.print("^C\r\n");
+          this.wasmTty.print(currentInput + "^C\r\n");
           if (this.history) this.history.rewind();
 
           // Kill the command

--- a/packages/wasm-terminal/test/wasm-shell.test.ts
+++ b/packages/wasm-terminal/test/wasm-shell.test.ts
@@ -77,7 +77,7 @@ describe("WasmShell", () => {
       .catch(() => {
         expect(true).toBe(true);
       });
-    wasmShell.abortRead();
+    wasmShell.rejectActiveRead();
 
     await waitForCurrentEventsOnCallStack();
   });


### PR DESCRIPTION
closes #106 
closes #108 

This fixes CTRL+C placing users in an unresponsive state.

# Example

The fix for #108 Is shown in the picture after the gif 😄 

![unresponsivePrompt](https://user-images.githubusercontent.com/1448289/66614682-cbda5180-eb7e-11e9-8ef9-d288d0c3a9e1.gif)

<img width="634" alt="Screen Shot 2019-10-10 at 5 35 36 PM" src="https://user-images.githubusercontent.com/1448289/66616163-86b91e00-eb84-11e9-8b5a-b8ecc0383f56.png">
