### PR TITLE
Inlined Assets for Wasm Terminal

### DIFF
--- a/examples/wasm-shell/components/wasm-terminal.tsx
+++ b/examples/wasm-shell/components/wasm-terminal.tsx
@@ -5,7 +5,7 @@ import WasmTerminal, {
   // @ts-ignore
   fetchCommandFromWAPM
   // @ts-ignore
-} from "../../../packages/wasm-terminal/dist/index.esm";
+} from "../../../packages/wasm-terminal/dist/optimized/wasm-terminal.esm";
 
 // @ts-ignore
 import wasmInit, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19629,6 +19629,19 @@
         "rollup-pluginutils": "^2.6.0"
       }
     },
+    "rollup-plugin-terser": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.2.tgz",
+      "integrity": "sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^24.6.0",
+        "rollup-pluginutils": "^2.8.1",
+        "serialize-javascript": "^1.7.0",
+        "terser": "^4.1.0"
+      }
+    },
     "rollup-plugin-typescript": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-typescript/-/rollup-plugin-typescript-1.0.1.tgz",
@@ -19802,6 +19815,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
       "dev": true
     },
     "serve": {
@@ -20705,6 +20724,25 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        }
+      }
+    },
+    "terser": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
+      "integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "postinstall": "npx run-s lerna:bootstrap",
     "build": "npx run-s lerna:build wasm-shell:build",
+    "build:dev": "npx run-s lerna:build:dev wasm-shell:build:dev",
     "deploy": "npx run-s wasm-transformer:build lerna:build lerna:publish",
     "serve": "npx serve dist/ -p 8000",
     "dev": "npx run-p wasm-terminal:dev dev:watch serve",
@@ -81,6 +82,7 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-postcss": "^2.0.3",
     "rollup-plugin-replace": "^2.2.0",
+    "rollup-plugin-terser": "^5.1.2",
     "rollup-plugin-typescript": "^1.0.1",
     "rollup-plugin-typescript2": "^0.22.1",
     "rollup-plugin-url": "^2.2.2",

--- a/packages/wasm-terminal/README.md
+++ b/packages/wasm-terminal/README.md
@@ -9,6 +9,8 @@ A terminal-like component for the browser, that fetches and runs Wasm modules in
 - [Features](#features)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+  - [Unoptimized](#unoptimized)
+  - [Optimized](#optimized)
 - [Wasm Terminal Reference API](#wasm-terminal-reference-api)
   - [WasmTerminal](#wasmterminal)
   - [fetchCommandFromWAPM](#fetchcommandfromwapm)
@@ -97,6 +99,8 @@ wasmTerminal.focus();
 // wasmTerminal.destroy();
 ```
 
+**NOTE:** Remember to include the CSS file mentioned at the beginning of the "Quick Start" section.
+
 ### Optimized
 
 Optimized bundles, for both `@wasmer/wasm-terminal` and `@wasmer/wasm-transfoormer`, prioritize performance. For examples, assets required by the library must be passed in manually.
@@ -153,6 +157,8 @@ wasmTerminal.focus();
 // Later, when we are done with the terminal, let's destroy it
 // wasmTerminal.destroy();
 ```
+
+**NOTE:** Remember to include the CSS file mentioned at the beginning of the "Quick Start" section.
 
 ## Wasm Terminal Reference API
 

--- a/packages/wasm-terminal/lib/command-runner/command-runner.ts
+++ b/packages/wasm-terminal/lib/command-runner/command-runner.ts
@@ -10,6 +10,11 @@ import WasmTerminalConfig from "../wasm-terminal-config";
 
 import WasmTty from "../wasm-tty/wasm-tty";
 
+/*ROLLUP_REPLACE_INLINE
+// @ts-ignore
+import processWorkerInlinedUrl from "../../dist/workers/process.worker.js";
+ROLLUP_REPLACE_INLINE*/
+
 let processWorkerBlobUrl: string | undefined;
 
 export default class CommandRunner {
@@ -184,9 +189,14 @@ export default class CommandRunner {
       throw new Error("Terminal Config missing the Process Worker URL");
     }
 
+    let processWorkerUrl = this.wasmTerminalConfig.processWorkerUrl;
+    /*ROLLUP_REPLACE_INLINE
+    processWorkerUrl = processWorkerInlinedUrl;
+    ROLLUP_REPLACE_INLINE*/
+
     // Generate our process
     const workerBlobUrl = await this._getBlobUrlForProcessWorker(
-      this.wasmTerminalConfig.processWorkerUrl,
+      processWorkerUrl,
       this.wasmTty
     );
     const processWorker = new Worker(workerBlobUrl);

--- a/packages/wasm-terminal/lib/wasm-terminal-config.ts
+++ b/packages/wasm-terminal/lib/wasm-terminal-config.ts
@@ -32,6 +32,14 @@ export default class WasmTerminalConfig {
       );
     }
 
+    /*ROLLUP_REPLACE_INLINE
+    if (config.processWorkerUrl) {
+      console.warn(
+        "The unoptimized bundle of wasm-terminal is currently being used. The process worker does not need to be passed, as it is already inlined into the bundle. If you would like to pass in the process worker url and improve performance, please use the optimized bundle. Instructions can be found in the documentation."
+      );
+    }
+    ROLLUP_REPLACE_INLINE*/
+
     // Assign our values
     this.fetchCommand = config.fetchCommand;
     this.processWorkerUrl = config.processWorkerUrl;

--- a/packages/wasm-terminal/package.json
+++ b/packages/wasm-terminal/package.json
@@ -2,8 +2,8 @@
   "name": "@wasmer/wasm-terminal",
   "version": "0.2.3",
   "description": "A terminal-like component for the browser, that fetches and runs Wasm modules in the context of a shell. 🐚",
-  "module": "dist/index.esm.js",
-  "browser": "dist/index.iife.js",
+  "module": "dist/unoptimized/wasm-terminal.esm.js",
+  "browser": "dist/unoptimized/wasm-terminal.iife.js",
   "typings": "dist/packages/wasm-terminal/lib/index.d.ts",
   "files": [
     "dist",

--- a/packages/wasm-transformer/lib/optimized.ts
+++ b/packages/wasm-transformer/lib/optimized.ts
@@ -1,8 +1,9 @@
 export * from "../wasm-pack/web/wasm_transformer";
 
+// @ts-ignore
 import init from "../wasm-pack/web/wasm_transformer";
 
-export const wasmTransformerInit = async passedWasmTransformerUrl => {
+export const wasmTransformerInit = async (passedWasmTransformerUrl: string) => {
   await init(passedWasmTransformerUrl);
 };
 

--- a/packages/wasm-transformer/lib/unoptimized.ts
+++ b/packages/wasm-transformer/lib/unoptimized.ts
@@ -1,10 +1,13 @@
+// @ts-ignore
 import wasmTransformerWasmUrl from "../wasm-pack/web/wasm_transformer_bg.wasm";
 
+// @ts-ignore
 import * as wasmTransformerWasmPack from "../wasm-pack/web/wasm_transformer";
 
-const initPromise = wasmTransformerWasmPack.init(wasmTransformerWasmUrl);
+// @ts-ignore
+const initPromise = wasmTransformerWasmPack.default(wasmTransformerWasmUrl);
 
-export const lowerI64Imports = async wasmBinary => {
+export const lowerI64Imports = async (wasmBinary: Uint8Array) => {
   await initPromise;
   return wasmTransformerWasmPack.lowerI64Imports(wasmBinary);
 };

--- a/packages/wasm-transformer/package.json
+++ b/packages/wasm-transformer/package.json
@@ -5,6 +5,7 @@
   "main": "dist/wasm-pack/node/wasm_transformer.js",
   "module": "dist/unoptimized/wasm-transformer.esm.js",
   "browser": "dist/unoptimized/wasm-transformer.iife.js",
+  "typings": "dist/unoptimized/packages/wasm-transformer/lib/unoptimized.d.ts",
   "files": [
     "dist",
     "package.json",

--- a/packages/wasm-transformer/rollup.config.js
+++ b/packages/wasm-transformer/rollup.config.js
@@ -4,6 +4,7 @@ import resolve from "rollup-plugin-node-resolve";
 import commonjs from "rollup-plugin-commonjs";
 import builtins from "rollup-plugin-node-builtins";
 import globals from "rollup-plugin-node-globals";
+import typescript from "rollup-plugin-typescript2";
 import json from "rollup-plugin-json";
 import replace from "rollup-plugin-replace";
 import compiler from "@ampproject/rollup-plugin-closure-compiler";
@@ -12,6 +13,13 @@ import url from "rollup-plugin-url";
 import pkg from "./package.json";
 
 const sourcemapOption = process.env.PROD ? undefined : "inline";
+
+let typescriptPluginOptions = {
+  tsconfig: "../../tsconfig.json",
+  exclude: ["./test/**/*"],
+  clean: process.env.PROD ? true : false,
+  objectHashIgnoreUnknownHack: true
+};
 
 const replaceNodeOptions = {
   delimiters: ["", ""],
@@ -46,11 +54,11 @@ const inlineUrlPlugin = url({
 const plugins = [
   replace(replaceWASIJsTransformerOptions),
   resolve({ preferBuiltins: true }),
+  typescript(typescriptPluginOptions),
   commonjs(),
   globals(),
   builtins(),
   json(),
-  // Closure Compiler does not like the wasm-pack output
   // process.env.PROD ? compiler() : undefined,
   process.env.PROD ? bundleSize() : undefined
 ];
@@ -65,7 +73,7 @@ const optimizedBrowserPlugins = [replace(replaceBrowserOptions), ...plugins];
 
 const unoptimizedBundles = [
   {
-    input: "./lib/unoptimized.js",
+    input: "./lib/unoptimized.ts",
     output: {
       file: "dist/unoptimized/wasm-transformer.esm.js",
       format: "esm",
@@ -77,7 +85,7 @@ const unoptimizedBundles = [
     plugins: unoptimizedBrowserPlugins
   },
   {
-    input: "./lib/unoptimized.js",
+    input: "./lib/unoptimized.ts",
     output: {
       file: "dist/unoptimized/wasm-transformer.iife.js",
       format: "iife",
@@ -94,7 +102,7 @@ const unoptimizedBundles = [
 
 const optimizedBundles = [
   {
-    input: "./lib/optimized.js",
+    input: "./lib/optimized.ts",
     output: {
       file: "dist/optimized/wasm-transformer.esm.js",
       format: "esm",
@@ -106,7 +114,7 @@ const optimizedBundles = [
     plugins: optimizedBrowserPlugins
   },
   {
-    input: "./lib/optimized.js",
+    input: "./lib/optimized.ts",
     output: {
       file: "dist/optimized/wasm-transformer.iife.js",
       format: "iife",

--- a/packages/wasm-transformer/rollup.config.js
+++ b/packages/wasm-transformer/rollup.config.js
@@ -82,6 +82,7 @@ const unoptimizedBundles = [
       file: "dist/unoptimized/wasm-transformer.iife.js",
       format: "iife",
       name: "WasmTransformer",
+      exports: "named",
       sourcemap: sourcemapOption
     },
     watch: {
@@ -110,6 +111,7 @@ const optimizedBundles = [
       file: "dist/optimized/wasm-transformer.iife.js",
       format: "iife",
       name: "WasmTransformer",
+      exports: "named",
       sourcemap: sourcemapOption
     },
     watch: {


### PR DESCRIPTION
relates to #121 
relates to #119 

* Creates optimizied and unoptimized bundles
* Inlines the process worker for unoptimized bundles
* Fixes for #119 , forgot to transpile the bundles 😄 

# Example

<img width="1225" alt="Screen Shot 2019-10-15 at 1 42 27 PM" src="https://user-images.githubusercontent.com/1448289/66868526-555c9b80-ef52-11e9-8a7e-e3d8740bf799.png">
