### PR TITLE
wasm-terminal: New Interfaces for CommandOptions

### DIFF
--- a/packages/wasm-terminal/lib/command-runner/command-runner.ts
+++ b/packages/wasm-terminal/lib/command-runner/command-runner.ts
@@ -4,7 +4,7 @@ import * as Comlink from "../../node_modules/comlink/src/comlink";
 import parse from "shell-parse";
 
 import Process from "../process/process";
-import { CommandOptions } from "./command";
+import { WasmCommandOptions, CallbackCommandOptions } from "./command";
 
 import WasmTerminalConfig from "../wasm-terminal-config";
 
@@ -343,9 +343,9 @@ export default class CommandRunner {
     ast: any,
     wasmTerminalConfig: WasmTerminalConfig,
     wasmTty?: WasmTty
-  ): Promise<Array<CommandOptions>> {
+  ): Promise<Array<WasmCommandOptions | CallbackCommandOptions>> {
     // The array of command options we are returning
-    let commandOptions: Array<CommandOptions> = [];
+    let commandOptions: Array<WasmCommandOptions | CallbackCommandOptions> = [];
 
     let commandName = ast.command.value;
     let commandArgs = ast.args.map((arg: any) => arg.value);
@@ -390,18 +390,22 @@ export default class CommandRunner {
       // Compile the Wasm Module
       const wasmModule = await WebAssembly.compile(response);
 
-      commandOptions.unshift({
+      const wasmCommandOptions: WasmCommandOptions = {
         args,
         env,
         module: wasmModule
-      });
+      };
+
+      commandOptions.unshift(wasmCommandOptions);
     } else {
-      commandOptions.unshift({
+      const callbackCommandOptions: CallbackCommandOptions = {
         args,
         env,
         // @ts-ignore
         callback: response
-      });
+      };
+
+      commandOptions.unshift(callbackCommandOptions);
     }
 
     return commandOptions;

--- a/packages/wasm-terminal/lib/command-runner/command.ts
+++ b/packages/wasm-terminal/lib/command-runner/command.ts
@@ -2,12 +2,18 @@
 
 import { Duplex } from "stream";
 
-export type CommandOptions = {
+interface CommandOptions {
   args: string[];
   env: { [key: string]: string };
-  module?: WebAssembly.Module;
-  callback?: Function;
-};
+}
+
+export interface WasmCommandOptions extends CommandOptions {
+  module: WebAssembly.Module;
+}
+
+export interface CallbackCommandOptions extends CommandOptions {
+  callback: Function;
+}
 
 export class Command {
   args: string[];

--- a/packages/wasm-terminal/lib/process/process.ts
+++ b/packages/wasm-terminal/lib/process/process.ts
@@ -1,11 +1,14 @@
 import WASI from "@wasmer/wasi";
 
-import { CommandOptions } from "../command-runner/command";
+import {
+  WasmCommandOptions,
+  CallbackCommandOptions
+} from "../command-runner/command";
 
 import WASICommand from "./wasi-command";
 
 export default class Process {
-  commandOptions: CommandOptions;
+  commandOptions: WasmCommandOptions | CallbackCommandOptions;
   dataCallback: Function;
   endCallback: Function;
   errorCallback: Function;
@@ -16,7 +19,7 @@ export default class Process {
   callbackCommand?: any;
 
   constructor(
-    commandOptions: CommandOptions,
+    commandOptions: WasmCommandOptions | CallbackCommandOptions,
     dataCallback: Function,
     endCallback: Function,
     errorCallback: Function,
@@ -33,14 +36,14 @@ export default class Process {
       sharedStdin = new Int32Array(sharedStdinBuffer);
     }
 
-    if (commandOptions.module) {
+    if ((commandOptions as WasmCommandOptions).module) {
       this.wasiCommand = new WASICommand(
-        commandOptions,
+        commandOptions as WasmCommandOptions,
         sharedStdin,
         startStdinReadCallback
       );
     } else {
-      this.callbackCommand = commandOptions.callback;
+      this.callbackCommand = (commandOptions as CallbackCommandOptions).callback;
     }
   }
 

--- a/packages/wasm-terminal/lib/process/wasi-command.ts
+++ b/packages/wasm-terminal/lib/process/wasi-command.ts
@@ -3,7 +3,7 @@
 import WASI from "@wasmer/wasi";
 import WasmFs from "@wasmer/wasmfs";
 
-import { Command, CommandOptions } from "../command-runner/command";
+import { Command, WasmCommandOptions } from "../command-runner/command";
 
 import { Duplex, PassThrough } from "stream";
 
@@ -62,7 +62,7 @@ export default class WASICommand extends Command {
   stdoutCallback?: Function;
 
   constructor(
-    options: CommandOptions,
+    options: WasmCommandOptions,
     sharedStdin?: Int32Array,
     startStdinReadCallback?: Function
   ) {


### PR DESCRIPTION
* Implements `WasmCommandOptions` and `CallbackCommandOptions` as interfaces that extend a base `CommandOptions` interface 😄 

# Example

<img width="714" alt="Screen Shot 2019-10-15 at 3 36 50 PM" src="https://user-images.githubusercontent.com/1448289/66875010-ba6bbd80-ef61-11e9-85c6-1402e97dafb5.png">
