### PR TITLE
Cleaned up the errors when testing the wasm_transformer crate

### DIFF
--- a/crates/wasm_transformer/src/applier.rs
+++ b/crates/wasm_transformer/src/applier.rs
@@ -210,10 +210,7 @@ pub fn apply_transformations_to_wasm_binary_vec(
                         - (function_size_byte_length as isize)) as isize;
                 calls_byte_offset += function_size_byte_length_difference + byte_length_difference;
             }
-
-            // Add the byte_length_difference
         }
-        // calls_byte_offset += byte_length_difference;
     }
 
     // Add the trampoline functions to the code section
@@ -262,11 +259,6 @@ fn add_entries_to_section(
     // Section size
     let section_length_position =
         (starting_offset + (section.start_position as isize) + 1) as usize;
-    // let (section_length, section_length_bytes) = read_bytes_as_varunit(
-    //     wasm_binary_vec
-    //         .get(section_length_position..(section_length_position + 5))
-    //         .unwrap(),
-    // )?;
     let section_length = section.size;
     let section_length_bytes = section.size_byte_length;
 

--- a/crates/wasm_transformer/src/transformer.rs
+++ b/crates/wasm_transformer/src/transformer.rs
@@ -100,7 +100,7 @@ fn converts() {
         console_log!(" ");
 
         console_log!(" ");
-        console_log!("Convert Back to Wat for descriptive errors (if there is one)");
+        console_log!("Outputting errors (if there are some)");
         console_log!(" ");
 
         let transformed_wat = wabt::wasm2wat(wasm.to_vec());
@@ -108,7 +108,7 @@ fn converts() {
         match transformed_wat {
             Err(e) => {
                 console_log!(" ");
-                console_log!("Test File Path: {:?}", test_file_path);
+                console_log!("wasm2wat Error:");
                 console_log!(" ");
                 console_log!("{:?}", e);
                 console_log!(" ");
@@ -126,7 +126,7 @@ fn converts() {
         let validated = wasmparser::validate(&wasm, None);
         assert!(
             !validated.is_err(),
-            "converted Wasm is not valid: {:?}",
+            "Converted Wasm is not valid (Error with Hex values): {:X?}",
             validated.err()
         );
     }

--- a/crates/wasm_transformer/src/transformer.rs
+++ b/crates/wasm_transformer/src/transformer.rs
@@ -124,10 +124,15 @@ fn converts() {
         }
 
         let validated = wasmparser::validate(&wasm, None);
-        assert!(
-            !validated.is_err(),
-            "Converted Wasm is not valid (Error with Hex values): {:X?}",
-            validated.err()
-        );
+
+        if validated.is_err() {
+            console_log!(" ");
+            console_log!("wasmparser::validate Error (as Hex Values):");
+            console_log!(" ");
+            console_log!("{:X?}", validated.err());
+            console_log!(" ");
+        }
+
+        assert!(!validated.is_err(), "Validation Assertion Failed.");
     }
 }


### PR DESCRIPTION
closes #99 

* Gives a cleaner error output for the wasm_transformer crate tests.
* Removed some commented out code that was no longer neccessary.

# Example

<img width="717" alt="Screen Shot 2019-10-16 at 4 44 54 PM" src="https://user-images.githubusercontent.com/1448289/66967122-b2308280-f034-11e9-94e7-5b7187f09082.png">
