### PR TITLE
fix poll_oneoff timer

### DIFF
--- a/packages/wasi/lib/wasi.ts
+++ b/packages/wasi/lib/wasi.ts
@@ -1232,7 +1232,7 @@ class WASI {
               const absolute = subclockflags === 1;
 
               let e = WASI_ESUCCESS;
-              const n = now(clockid);
+              const n = BigInt(now(clockid));
               if (n === null) {
                 e = WASI_EINVAL;
               } else {


### PR DESCRIPTION
Hello,

timestamp is always BigInt, whilst now() returns number n is a number. poll_oneoff fails to add `n+timestamp` on the following line:
https://github.com/wasmerio/wasmer-js/blob/master/packages/wasi/lib/wasi.ts#L1239