### PR TITLE
Fixed processes from being terminated too early with pending stdout

### DIFF
--- a/packages/wasm-terminal/lib/process/process.ts
+++ b/packages/wasm-terminal/lib/process/process.ts
@@ -68,9 +68,12 @@ export default class Process {
     );
 
     commandStream.on("end", () => {
-      // TODO: Diff the two objects and only send that back
-      const currentWasmFsJson = this.wasmFs.toJSON();
-      this.endCallback(currentWasmFsJson);
+      // Set timeout to allow any lingering data callback to be launched out
+      setTimeout(() => {
+        // TODO: Diff the two objects and only send that back
+        const currentWasmFsJson = this.wasmFs.toJSON();
+        this.endCallback(currentWasmFsJson);
+      }, 100);
     });
 
     try {
@@ -83,7 +86,11 @@ export default class Process {
 
       if (e.code === 0) {
         // Command was successful, but ended early.
-        this.endCallback(currentWasmFsJson);
+
+        // Set timeout to allow any lingering data callback to be launched out
+        setTimeout(() => {
+          this.endCallback(currentWasmFsJson);
+        }, 100);
         return;
       }
 


### PR DESCRIPTION
This fixes process from terminating too early when they still had stdout to send over the worker through the data callback. 😄 

# Example

![earlyTerminate](https://user-images.githubusercontent.com/1448289/67522631-ed990580-f661-11e9-919f-5c802f10be5b.gif)
