### PR TITLE
Fixed wasm terminal inherits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2762,8 +2762,8 @@
     "@wasmer/wasm-terminal": {
       "version": "file:packages/wasm-terminal",
       "requires": {
-        "@wasmer/wasi": "^0.3.0",
-        "@wasmer/wasmfs": "^0.3.0",
+        "@wasmer/wasi": "^0.3.1",
+        "@wasmer/wasmfs": "^0.3.1",
         "comlink": "^4.0.5",
         "shell-parse": "0.0.2",
         "shell-quote": "^1.7.1",

--- a/packages/wasm-terminal/lib/wasm-terminal.ts
+++ b/packages/wasm-terminal/lib/wasm-terminal.ts
@@ -1,5 +1,5 @@
 // The Wasm Terminal
-import * as xterm from "xterm";
+import xterm from "xterm";
 const Terminal = xterm.Terminal;
 import { FitAddon } from "xterm-addon-fit";
 import { WebLinksAddon } from "xterm-addon-web-links";

--- a/packages/wasm-terminal/package-lock.json
+++ b/packages/wasm-terminal/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@wasmer/wasi": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-0.3.0.tgz",
-      "integrity": "sha512-+Yw0P8DK6FAdSvVEnHTNilXnD1adVr2HrLBPW0Ol1r0ReIlHQMoMFsE+Y7Nx+pRFZyeakqq8sSKis72uxHVwxA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-0.3.1.tgz",
+      "integrity": "sha512-Vqa3Wr1v09g2GwUHBHedROe6UrLNLX3gqAzzVW8pRM3AVtxpE5/C4+cZjHXHnA8b7MaKHZwqIkB/3OeQKFrOKg==",
       "requires": {
         "browser-process-hrtime": "^1.0.0",
         "buffer-es6": "^4.9.3",
@@ -16,9 +16,9 @@
       }
     },
     "@wasmer/wasmfs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasmfs/-/wasmfs-0.3.0.tgz",
-      "integrity": "sha512-9D856PBJWZEl/AfxsYagE5U/Z5iKH8hzoDMLmqQIQb9KJ9+AzwQd9iPYcroLaiQsLzeEqNY1Bh/o4OIldAelEA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasmfs/-/wasmfs-0.3.1.tgz",
+      "integrity": "sha512-Kdf6EY67Z9FUAb2/Tb6rA74jVv4zbxc63rU3wl9Ens7DrLQLbfkivc7ZQuyLvQXwKly70Q5u+IIHQ8iwdFiqFA==",
       "requires": {
         "memfs": "git+https://github.com/torch2424/memfs.git#wasmfs-fixes"
       }
@@ -64,7 +64,7 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "memfs": {
-      "version": "git+https://github.com/torch2424/memfs.git#wasmfs-fixes",
+      "version": "git+https://github.com/torch2424/memfs.git#50997b4374121eb30e4e571a311e3effe824ea82",
       "from": "git+https://github.com/torch2424/memfs.git#wasmfs-fixes",
       "requires": {
         "browser-assert": "^1.2.1",
@@ -95,9 +95,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "shell-parse": {
       "version": "0.0.2",

--- a/packages/wasmfs/package-lock.json
+++ b/packages/wasmfs/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "browser-assert": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
+      "integrity": "sha1-mqpaKox0aFwq4Fv+Ru/WBvBowgA="
+    },
     "fast-extend": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/fast-extend/-/fast-extend-0.0.2.tgz",
@@ -15,9 +20,10 @@
       "integrity": "sha512-FNUvuTAJ3CqCQb5ELn+qCbGR/Zllhf2HtwsdAtBi59s1WeCjKMT81fHcSu7dwIskqGVK+MmOrb7VOBlq3/SItw=="
     },
     "memfs": {
-      "version": "git+https://github.com/torch2424/memfs.git#f4101e4e1f06b33372e0b3bb6fda230a8fcd0c62",
+      "version": "git+https://github.com/torch2424/memfs.git#wasmfs-fixes",
       "from": "git+https://github.com/torch2424/memfs.git#wasmfs-fixes",
       "requires": {
+        "browser-assert": "^1.2.1",
         "fast-extend": "0.0.2",
         "fs-monkey": "^0.3.3"
       }


### PR DESCRIPTION
Was a one line fix 😂 Was improperly importing xterm on the newest version, which cause things to break.

Other changes are just general dependency updating in package lock

# Example

<img width="1320" alt="Screen Shot 2019-10-25 at 3 13 22 PM" src="https://user-images.githubusercontent.com/1448289/67607697-40de8700-f73a-11e9-88ab-e5dcae6fe66e.png">
