### PR TITLE
E2E Tests: Increased timeout, and investigating why azure passes on error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,12 +29,14 @@ steps:
     displayName: "npm install and build"
 
   - script: |
+      npm test
+    displayName: "npm test"
+
+  - script: |
       cd e2e-tests
       npm install
       npm run test
+      # Exit if the npm run test was not a success
+      if [ $? -ne 0 ] ; then exit 1 ; fi
       cd ..
     displayName: "End to End (E2E) Tests"
-
-  - script: |
-      npm test
-    displayName: "npm test"

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "npx mocha --exit"
+    "test": "npx mocha --exit --timeout 5000"
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",

--- a/e2e-tests/test/wasi.js
+++ b/e2e-tests/test/wasi.js
@@ -68,7 +68,9 @@ describe("@wasmer/wasi", function() {
     await testBrowserBundle(bundle);
   });
 
-  it("Should fail", () => {
-    assert.equal(true, false);
+  it("Should timeout", () => {
+    return new Promise(resolve => {
+      // Never resolve
+    });
   });
 });

--- a/e2e-tests/test/wasi.js
+++ b/e2e-tests/test/wasi.js
@@ -67,4 +67,8 @@ describe("@wasmer/wasi", function() {
 
     await testBrowserBundle(bundle);
   });
+
+  it("Should fail", () => {
+    assert.equal(true, false);
+  });
 });

--- a/e2e-tests/test/wasi.js
+++ b/e2e-tests/test/wasi.js
@@ -67,10 +67,4 @@ describe("@wasmer/wasi", function() {
 
     await testBrowserBundle(bundle);
   });
-
-  it("Should timeout", () => {
-    return new Promise(resolve => {
-      // Never resolve
-    });
-  });
 });


### PR DESCRIPTION
Per the last PR #142 , Seemed like some tests timed out: https://dev.azure.com/wasmerio/wasmer-js/_build/results?buildId=1698

Thus, increased the timeout, and also, tried to fix Azure devops continuing our script even though it exited with exit code 2.