### PR TITLE
Wasmfs bundle bug

### DIFF
--- a/e2e-tests/test/wasmfs.js
+++ b/e2e-tests/test/wasmfs.js
@@ -14,6 +14,17 @@ const testNodeBundle = async bundleString => {
 
   wasmFs.fs.writeFileSync("/dev/stdout", message);
 
+  const BASE64_IMG =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+  const expectedBinary = new Uint8Array(new Buffer(BASE64_IMG, "base64"));
+  wasmFs.fs.mkdirSync("/tmp/", { recursive: true });
+  wasmFs.volume.writeFileSync("/tmp/test.png", expectedBinary);
+
+  console.log(wasmFs.toJSON()["/tmp/test.png"]);
+  if (wasmFs.toJSON()["/tmp/test.png"] !== BASE64_IMG) {
+    throw new Error("Serialization doesn't work");
+  }
+
   const stdout = await wasmFs.getStdOut();
 
   assert.equal(stdout, message);
@@ -37,6 +48,14 @@ const testBrowserBundle = async bundleString => {
 
       wasmFs.fs.writeFileSync("/dev/stdout", message);
 
+      const BASE64_IMG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const expectedBinary = Uint8Array.from(atob(BASE64_IMG), c => c.charCodeAt(0));
+      wasmFs.fs.mkdirSync("/tmp/", { recursive: true });
+      wasmFs.volume.writeFileSync("/tmp/test.png", expectedBinary);
+      
+      if (wasmFs.toJSON()["/tmp/test.png"] !== BASE64_IMG) {
+        throw new Error("Serialization doesn't work");
+      }
       wasmFs !== undefined;
     `);
 

--- a/packages/wasmfs/src/index.ts
+++ b/packages/wasmfs/src/index.ts
@@ -49,7 +49,7 @@ export default class WasmFsDefault {
       if (node.isFile()) {
         let filename = child.getPath();
         if (path) filename = relative(path, filename);
-        json[filename] = node.getString(encoding);
+        json[filename] = node.getBuffer();
       } else if (node.isDirectory()) {
         this._toJSON(child, json, path);
       }
@@ -96,15 +96,16 @@ export default class WasmFsDefault {
     const sep = "/";
     for (let filename in json) {
       const data = json[filename];
-
-      if (typeof data === "string") {
+      const isDir = Object.getPrototypeOf(data) === null;
+      // const isDir = typeof data === "string" || ((data as any) instanceof Buffer && data !== null);
+      if (!isDir) {
         const steps = filenameToSteps(filename);
         if (steps.length > 1) {
           const dirname = sep + steps.slice(0, steps.length - 1).join(sep);
           // @ts-ignore
           vol.mkdirpBase(dirname, 0o777);
         }
-        vol.writeFileSync(filename, data, { encoding: encoding });
+        vol.writeFileSync(filename, data as any);
       } else {
         // @ts-ignore
         vol.mkdirpBase(filename, 0o777);


### PR DESCRIPTION
This PR fixes the bug when serializing/deserializing by using `Uint8Array` directly to skip serialization (base64 or utf8).

It also adds end to end testing to WasmFs