### PR TITLE
Refactor command

### DIFF
--- a/examples/wasm-shell/components/wasm-terminal.tsx
+++ b/examples/wasm-shell/components/wasm-terminal.tsx
@@ -18,9 +18,11 @@ import { WasmFs } from "@wasmer/wasmfs";
 WASI.defaultBindings = BrowserWASIBindings;
 
 const commands = {
-  callback: (args: string[], stdin: string) => {
+  callback: (options: any, wasmFs: any) => {
+    let myArr = new Uint8Array(1024);
+    let stdin = wasmFs.fs.readSync(0, myArr, 0, 1024, 0);
     return Promise.resolve(
-      `Callback Command Working! Args: ${args}, stdin: ${stdin}`
+      `Callback Command Working! Options: ${options}, stdin: ${myArr}`
     );
   }
 };

--- a/packages/wasm-terminal/README.md
+++ b/packages/wasm-terminal/README.md
@@ -66,8 +66,8 @@ import { lowerI64Imports } from "@wasmer/wasm-transformer";
 const fetchCommandHandler = async commandName => {
   // Let's return a "CallbackCommand" if our command matches a special name
   if (commandName === "callback-command") {
-    const callbackCommand = async (args, stdin) => {
-      return `Callback Command Working! Args: ${args}, stdin: ${stdin}`;
+    const callbackCommand = async (options, wasmFs) => {
+      return `Callback Command Working! Options: ${options}, fs: ${wasmFs}`;
     };
     return callbackCommand;
   }
@@ -121,8 +121,8 @@ const wasmTransformerWasmUrl =
 const fetchCommandHandler = async commandName => {
   // Let's return a "CallbackCommand" if our command matches a special name
   if (commandName === "callback-command") {
-    const callbackCommand = async (args, stdin) => {
-      return `Callback Command Working! Args: ${args}, stdin: ${stdin}`;
+    const callbackCommand = async (options, wasmFs) => {
+      return `Callback Command Working! Options: ${options}, fs: ${wasmFs}`;
     };
     return callbackCommand;
   }
@@ -190,9 +190,9 @@ CallbackCommands are functions that can be returned in the `fetchCommand` config
 
 ```typescript
 export type CallbackCommand = (
-  args: string[],
-  stdin: string
-) => Promise<string | undefined>;
+  options: CommandOptions,
+  wasmFs: WasmFs
+) => Promise<string | undefined> | string | undefined;
 ```
 
 ---

--- a/packages/wasm-terminal/src/command/callback-command.ts
+++ b/packages/wasm-terminal/src/command/callback-command.ts
@@ -22,8 +22,13 @@ export default class CallbackCommand extends Command {
     this.callback = options.callback;
   }
 
-  async run(pipedStdinData?: Uint8Array, stdoutCallback?: Function) {
-    let str = await Promise.resolve(this.callback(this.args, pipedStdinData));
-    stdoutCallback(new TextEncoder().encode(str + "\n"));
+  async run() {
+    // let myArr = new Uint8Array(1024);
+    // let pipedStdinData = this.wasmFs.fs.readSync(0, myArr, 0, 1024, 0);
+    let str = await Promise.resolve(this.callback(this.options.args));
+    this.wasmFs.fs.writeFileSync(
+      "/dev/stdout",
+      new TextEncoder().encode(str + "\n")
+    );
   }
 }

--- a/packages/wasm-terminal/src/command/callback-command.ts
+++ b/packages/wasm-terminal/src/command/callback-command.ts
@@ -23,10 +23,12 @@ export default class CallbackCommand extends Command {
   async run(wasmFs: WasmFs) {
     // let myArr = new Uint8Array(1024);
     // let pipedStdinData = this.wasmFs.fs.readSync(0, myArr, 0, 1024, 0);
-    let str = await Promise.resolve(this.callback(this.options.args));
-    wasmFs.fs.writeFileSync(
-      "/dev/stdout",
-      new TextEncoder().encode(str + "\n")
-    );
+    let str = await Promise.resolve(this.callback(this.options, wasmFs));
+    if (typeof str == "string") {
+      wasmFs.fs.writeFileSync(
+        "/dev/stdout",
+        new TextEncoder().encode(str + "\n")
+      );
+    }
   }
 }

--- a/packages/wasm-terminal/src/command/callback-command.ts
+++ b/packages/wasm-terminal/src/command/callback-command.ts
@@ -1,7 +1,6 @@
 import Command from "./command";
 import CommandOptions from "./command-options";
 import { WasmFs } from "@wasmer/wasmfs";
-import { Duplex } from "stream";
 
 // The class for WASI Commands
 export default class CallbackCommand extends Command {

--- a/packages/wasm-terminal/src/command/callback-command.ts
+++ b/packages/wasm-terminal/src/command/callback-command.ts
@@ -6,10 +6,9 @@ import { Duplex } from "stream";
 // The class for WASI Commands
 export default class CallbackCommand extends Command {
   callback: Function;
-  wasmFs: WasmFs;
   stdoutCallback?: Function;
 
-  constructor(options: CommandOptions, wasmFs: WasmFs) {
+  constructor(options: CommandOptions) {
     super(options);
 
     if (!options.callback) {
@@ -17,16 +16,15 @@ export default class CallbackCommand extends Command {
         "The Command Options provided are not for a Callback Command"
       );
     }
-    this.wasmFs = wasmFs;
 
     this.callback = options.callback;
   }
 
-  async run() {
+  async run(wasmFs: WasmFs) {
     // let myArr = new Uint8Array(1024);
     // let pipedStdinData = this.wasmFs.fs.readSync(0, myArr, 0, 1024, 0);
     let str = await Promise.resolve(this.callback(this.options.args));
-    this.wasmFs.fs.writeFileSync(
+    wasmFs.fs.writeFileSync(
       "/dev/stdout",
       new TextEncoder().encode(str + "\n")
     );

--- a/packages/wasm-terminal/src/command/callback-command.ts
+++ b/packages/wasm-terminal/src/command/callback-command.ts
@@ -1,11 +1,15 @@
 import Command from "./command";
 import CommandOptions from "./command-options";
+import { WasmFs } from "@wasmer/wasmfs";
+import { Duplex } from "stream";
 
 // The class for WASI Commands
 export default class CallbackCommand extends Command {
   callback: Function;
+  wasmFs: WasmFs;
+  stdoutCallback?: Function;
 
-  constructor(options: CommandOptions) {
+  constructor(options: CommandOptions, wasmFs: WasmFs) {
     super(options);
 
     if (!options.callback) {
@@ -13,11 +17,13 @@ export default class CallbackCommand extends Command {
         "The Command Options provided are not for a Callback Command"
       );
     }
+    this.wasmFs = wasmFs;
 
     this.callback = options.callback;
   }
 
-  run(stdin?: string) {
-    return this.callback(this.args, stdin);
+  async run(pipedStdinData?: Uint8Array, stdoutCallback?: Function) {
+    let str = await Promise.resolve(this.callback(this.args, pipedStdinData));
+    stdoutCallback(new TextEncoder().encode(str + "\n"));
   }
 }

--- a/packages/wasm-terminal/src/command/command.ts
+++ b/packages/wasm-terminal/src/command/command.ts
@@ -1,4 +1,3 @@
-import { Duplex } from "stream";
 import CommandOptions from "./command-options";
 
 export default class Command {
@@ -9,14 +8,7 @@ export default class Command {
     this.args = args;
     this.env = env;
   }
-  run(stdin?: string) {
-    throw new Error("Not implemented by the Command subclass");
+  async run(pipedStdinData?: Uint8Array, stdoutCallback?: Function) {
+    throw new Error("run not implemented by the Command subclass");
   }
-  instantiate(
-    stdoutCallback?: Function,
-    pipedStdinData?: Uint8Array
-  ): Promise<Duplex> {
-    throw new Error("Not implemented by the Command subclass");
-  }
-  async kill() {}
 }

--- a/packages/wasm-terminal/src/command/command.ts
+++ b/packages/wasm-terminal/src/command/command.ts
@@ -1,14 +1,12 @@
 import CommandOptions from "./command-options";
 
 export default class Command {
-  args: string[];
-  env: { [key: string]: string };
+  options: CommandOptions;
 
-  constructor({ args, env }: CommandOptions) {
-    this.args = args;
-    this.env = env;
+  constructor(options: CommandOptions) {
+    this.options = options;
   }
-  async run(pipedStdinData?: Uint8Array, stdoutCallback?: Function) {
+  async run() {
     throw new Error("run not implemented by the Command subclass");
   }
 }

--- a/packages/wasm-terminal/src/command/command.ts
+++ b/packages/wasm-terminal/src/command/command.ts
@@ -1,3 +1,4 @@
+import { WasmFs } from "@wasmer/wasmfs";
 import CommandOptions from "./command-options";
 
 export default class Command {
@@ -6,7 +7,7 @@ export default class Command {
   constructor(options: CommandOptions) {
     this.options = options;
   }
-  async run() {
+  async run(wasmFs: WasmFs) {
     throw new Error("run not implemented by the Command subclass");
   }
 }

--- a/packages/wasm-terminal/src/command/wasi-command.ts
+++ b/packages/wasm-terminal/src/command/wasi-command.ts
@@ -7,22 +7,16 @@ import CommandOptions from "./command-options";
 
 export default class WASICommand extends Command {
   wasi: WASI;
-  wasmFs: WasmFs;
-  module: WebAssembly.Module;
 
-  constructor(options: CommandOptions, wasmFs: WasmFs) {
+  constructor(options: CommandOptions) {
     super(options);
-
-    // Bind our stdinRead / stdoutWrite
-    this.wasmFs = wasmFs;
 
     if (!options.module) {
       throw new Error("Did not find a WebAssembly.Module for the WASI Command");
     }
-    this.module = options.module;
   }
 
-  async run() {
+  async run(wasmFs: WasmFs) {
     const wasi = new WASI({
       preopenDirectories: {
         "/": "/"
@@ -31,11 +25,11 @@ export default class WASICommand extends Command {
       args: this.options.args,
       bindings: {
         ...WASI.defaultBindings,
-        fs: this.wasmFs.fs
+        fs: wasmFs.fs
       }
     });
 
-    let instance = await WebAssembly.instantiate(this.module, {
+    let instance = await WebAssembly.instantiate(this.options.module, {
       wasi_unstable: wasi.wasiImport
     });
     wasi.start(instance);

--- a/packages/wasm-terminal/src/command/wasi-command.ts
+++ b/packages/wasm-terminal/src/command/wasi-command.ts
@@ -5,68 +5,16 @@ import { WasmFs } from "@wasmer/wasmfs";
 import Command from "./command";
 import CommandOptions from "./command-options";
 
-/**
-
- This function removes the ansi escape characters
- (normally used for printing colors and so)
- Inspired by: https://github.com/chalk/ansi-regex/blob/master/index.js
-
-MIT License
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-const cleanStdout = (stdout: string) => {
-  const pattern = [
-    "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
-    "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))"
-  ].join("|");
-
-  const regexPattern = new RegExp(pattern, "g");
-  return stdout.replace(regexPattern, "");
-};
-
 export default class WASICommand extends Command {
   wasi: WASI;
-  instantiateReponsePromise: Promise<WebAssembly.Instance>;
-  instance: WebAssembly.Instance | undefined;
   wasmFs: WasmFs;
+  module: WebAssembly.Module;
 
-  sharedStdin?: Int32Array;
-  startStdinReadCallback?: Function;
-  pipedStdin: string;
-  stdinPrompt: string = "";
-
-  readStdinCounter: number;
-
-  stdoutCallback?: Function;
-
-  constructor(
-    options: CommandOptions,
-    wasmFs: WasmFs,
-    sharedStdin?: Int32Array,
-    startStdinReadCallback?: Function
-  ) {
+  constructor(options: CommandOptions, wasmFs: WasmFs) {
     super(options);
 
     // Bind our stdinRead / stdoutWrite
     this.wasmFs = wasmFs;
-    this.wasmFs.volume.fds[0].node.read = this.stdinRead.bind(this);
-    this.wasmFs.volume.fds[1].node.write = this.stdoutWrite.bind(this);
-    this.wasmFs.volume.fds[2].node.write = this.stdoutWrite.bind(this);
-    const ttyFd = this.wasmFs.volume.openSync("/dev/tty", "w+");
-    this.wasmFs.volume.fds[ttyFd].node.read = this.stdinRead.bind(this);
-    this.wasmFs.volume.fds[ttyFd].node.write = this.stdoutWrite.bind(this);
-
-    this.sharedStdin = sharedStdin;
-    this.startStdinReadCallback = startStdinReadCallback;
-    this.readStdinCounter = 0;
-    this.pipedStdin = "";
 
     this.wasi = new WASI({
       preopenDirectories: {
@@ -83,110 +31,13 @@ export default class WASICommand extends Command {
     if (!options.module) {
       throw new Error("Did not find a WebAssembly.Module for the WASI Command");
     }
-
-    this.instantiateReponsePromise = WebAssembly.instantiate(options.module, {
-      wasi_unstable: this.wasi.wasiImport
-    });
+    this.module = options.module;
   }
 
   async run(pipedStdinData?: Uint8Array, stdoutCallback?: Function) {
-    this.instance = await this.instantiateReponsePromise;
-    // let stdoutRead = this.wasmFs.fs.createReadStream("/dev/stdout");
-    // let stderrRead = this.wasmFs.fs.createReadStream("/dev/stderr");
-
-    this.stdoutCallback = stdoutCallback;
-    if (pipedStdinData) {
-      this.pipedStdin = new TextDecoder("utf-8").decode(pipedStdinData);
-    }
-
-    if (!this.instance) {
-      throw new Error("You need to call instantiate first.");
-    }
-    this.wasi.start(this.instance);
-  }
-
-  stdoutWrite(
-    stdoutBuffer: Buffer | Uint8Array,
-    offset: number = 0,
-    length: number = stdoutBuffer.byteLength,
-    position?: number
-  ) {
-    if (this.stdoutCallback) {
-      this.stdoutCallback(stdoutBuffer);
-    }
-    let dataLines = new TextDecoder("utf-8").decode(stdoutBuffer).split("\n");
-    if (dataLines.length > 0) {
-      this.stdinPrompt = cleanStdout(dataLines[dataLines.length - 1]);
-    } else {
-      this.stdinPrompt = "";
-    }
-    return stdoutBuffer.length;
-  }
-
-  // Handle read of stdin, similar to C read
-  // https://linux.die.net/man/2/read
-  // This is the bottom of the "layers stack". This is the outer binding.
-  // This is the the thing that returns -1 because it is the actual file system,
-  // but it is up to WASI lib  (wasi.ts) to find out why this error'd
-  stdinRead(
-    stdinBuffer: Buffer | Uint8Array,
-    offset: number = 0,
-    length: number = stdinBuffer.byteLength,
-    position?: number
-  ) {
-    if (this.readStdinCounter > 0) {
-      this.readStdinCounter--;
-      return 0;
-    }
-    this.readStdinCounter = 1;
-
-    let responseStdin: string | null = null;
-    if (this.pipedStdin) {
-      responseStdin = this.pipedStdin;
-      this.pipedStdin = "";
-      this.readStdinCounter++;
-    } else if (this.sharedStdin && this.startStdinReadCallback) {
-      this.startStdinReadCallback();
-      Atomics.wait(this.sharedStdin, 0, -1);
-
-      // Grab the of elements
-      const numberOfElements = this.sharedStdin[0];
-      this.sharedStdin[0] = -1;
-      const newStdinData = new Uint8Array(numberOfElements);
-      for (let i = 0; i < numberOfElements; i++) {
-        newStdinData[i] = this.sharedStdin[1 + i];
-      }
-      responseStdin = new TextDecoder("utf-8").decode(newStdinData);
-    } else {
-      responseStdin = prompt(
-        `Please enter text for stdin:\n${this.stdinPrompt}`
-      );
-      if (responseStdin === null) {
-        if (this.stdoutCallback) {
-          this.stdoutCallback(new TextEncoder().encode("\n"));
-        }
-        const userError = new Error("Process killed by user");
-        (userError as any).user = true;
-        throw userError;
-        return -1;
-      }
-      responseStdin += "\n";
-      if (this.stdoutCallback) {
-        this.stdoutCallback(new TextEncoder().encode(responseStdin));
-      }
-    }
-
-    // First check for errors
-    if (!responseStdin) {
-      return 0;
-    }
-
-    const buffer = new TextEncoder().encode(responseStdin);
-    for (let x = 0; x < buffer.length; ++x) {
-      stdinBuffer[x] = buffer[x];
-    }
-
-    // Return the current stdin
-    return buffer.length;
+    let instance = await WebAssembly.instantiate(this.module, {
+      wasi_unstable: this.wasi.wasiImport
+    });
+    this.wasi.start(instance);
   }
 }

--- a/packages/wasm-terminal/src/command/wasi-command.ts
+++ b/packages/wasm-terminal/src/command/wasi-command.ts
@@ -6,8 +6,6 @@ import Command from "./command";
 import CommandOptions from "./command-options";
 
 export default class WASICommand extends Command {
-  wasi: WASI;
-
   constructor(options: CommandOptions) {
     super(options);
 

--- a/packages/wasm-terminal/src/command/wasi-command.ts
+++ b/packages/wasm-terminal/src/command/wasi-command.ts
@@ -27,9 +27,12 @@ export default class WASICommand extends Command {
       }
     });
 
-    let instance = await WebAssembly.instantiate(this.options.module, {
-      wasi_unstable: wasi.wasiImport
-    });
+    let instance = await WebAssembly.instantiate(
+      this.options.module as WebAssembly.Module,
+      {
+        wasi_unstable: wasi.wasiImport
+      }
+    );
     wasi.start(instance);
   }
 }

--- a/packages/wasm-terminal/src/command/wasi-command.ts
+++ b/packages/wasm-terminal/src/command/wasi-command.ts
@@ -16,28 +16,28 @@ export default class WASICommand extends Command {
     // Bind our stdinRead / stdoutWrite
     this.wasmFs = wasmFs;
 
-    this.wasi = new WASI({
-      preopenDirectories: {
-        "/": "/"
-      },
-      env: options.env,
-      args: options.args,
-      bindings: {
-        ...WASI.defaultBindings,
-        fs: this.wasmFs.fs
-      }
-    });
-
     if (!options.module) {
       throw new Error("Did not find a WebAssembly.Module for the WASI Command");
     }
     this.module = options.module;
   }
 
-  async run(pipedStdinData?: Uint8Array, stdoutCallback?: Function) {
-    let instance = await WebAssembly.instantiate(this.module, {
-      wasi_unstable: this.wasi.wasiImport
+  async run() {
+    const wasi = new WASI({
+      preopenDirectories: {
+        "/": "/"
+      },
+      env: this.options.env,
+      args: this.options.args,
+      bindings: {
+        ...WASI.defaultBindings,
+        fs: this.wasmFs.fs
+      }
     });
-    this.wasi.start(instance);
+
+    let instance = await WebAssembly.instantiate(this.module, {
+      wasi_unstable: wasi.wasiImport
+    });
+    wasi.start(instance);
   }
 }

--- a/packages/wasm-terminal/src/process/process.ts
+++ b/packages/wasm-terminal/src/process/process.ts
@@ -73,9 +73,9 @@ export default class Process {
     }
 
     if (commandOptions.module) {
-      this.command = new WASICommand(commandOptions, this.wasmFs);
+      this.command = new WASICommand(commandOptions);
     } else {
-      this.command = new CallbackCommand(commandOptions, this.wasmFs);
+      this.command = new CallbackCommand(commandOptions);
     }
 
     this.wasmFs.volume.fds[0].node.read = this.stdinRead.bind(this);
@@ -102,7 +102,7 @@ export default class Process {
       if (pipedStdinData) {
         this.pipedStdin = new TextDecoder("utf-8").decode(pipedStdinData);
       }
-      await this.command.run();
+      await this.command.run(this.wasmFs);
       end();
     } catch (e) {
       if (e.code === 0) {

--- a/packages/wasm-terminal/src/process/process.ts
+++ b/packages/wasm-terminal/src/process/process.ts
@@ -46,8 +46,6 @@ export default class Process {
 
   readStdinCounter: number;
 
-  stdoutCallback?: Function;
-
   command: Command;
 
   constructor(
@@ -101,11 +99,10 @@ export default class Process {
     };
 
     try {
-      this.stdoutCallback = this.dataCallback;
       if (pipedStdinData) {
         this.pipedStdin = new TextDecoder("utf-8").decode(pipedStdinData);
       }
-      await this.command.run(pipedStdinData, this.dataCallback);
+      await this.command.run();
       end();
     } catch (e) {
       if (e.code === 0) {
@@ -135,8 +132,8 @@ export default class Process {
     length: number = stdoutBuffer.byteLength,
     position?: number
   ) {
-    if (this.stdoutCallback) {
-      this.stdoutCallback(stdoutBuffer);
+    if (this.dataCallback) {
+      this.dataCallback(stdoutBuffer);
     }
     let dataLines = new TextDecoder("utf-8").decode(stdoutBuffer).split("\n");
     if (dataLines.length > 0) {
@@ -186,8 +183,8 @@ export default class Process {
         `Please enter text for stdin:\n${this.stdinPrompt}`
       );
       if (responseStdin === null) {
-        if (this.stdoutCallback) {
-          this.stdoutCallback(new TextEncoder().encode("\n"));
+        if (this.dataCallback) {
+          this.dataCallback(new TextEncoder().encode("\n"));
         }
         const userError = new Error("Process killed by user");
         (userError as any).user = true;
@@ -195,8 +192,8 @@ export default class Process {
         return -1;
       }
       responseStdin += "\n";
-      if (this.stdoutCallback) {
-        this.stdoutCallback(new TextEncoder().encode(responseStdin));
+      if (this.dataCallback) {
+        this.dataCallback(new TextEncoder().encode(responseStdin));
       }
     }
 

--- a/packages/wasm-terminal/src/process/process.ts
+++ b/packages/wasm-terminal/src/process/process.ts
@@ -5,6 +5,32 @@ import Command from "../command/command";
 import WASICommand from "../command/wasi-command";
 import CallbackCommand from "../command/callback-command";
 
+/**
+
+ This function removes the ansi escape characters
+ (normally used for printing colors and so)
+ Inspired by: https://github.com/chalk/ansi-regex/blob/master/index.js
+
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+const cleanStdout = (stdout: string) => {
+  const pattern = [
+    "[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)",
+    "(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))"
+  ].join("|");
+
+  const regexPattern = new RegExp(pattern, "g");
+  return stdout.replace(regexPattern, "");
+};
+
 export default class Process {
   commandOptions: CommandOptions;
   wasmFs: WasmFs;
@@ -14,6 +40,13 @@ export default class Process {
   errorCallback: Function;
   sharedStdin?: Int32Array;
   startStdinReadCallback?: Function;
+
+  pipedStdin: string;
+  stdinPrompt: string = "";
+
+  readStdinCounter: number;
+
+  stdoutCallback?: Function;
 
   command: Command;
 
@@ -42,15 +75,22 @@ export default class Process {
     }
 
     if (commandOptions.module) {
-      this.command = new WASICommand(
-        commandOptions,
-        this.wasmFs,
-        sharedStdin,
-        startStdinReadCallback
-      );
+      this.command = new WASICommand(commandOptions, this.wasmFs);
     } else {
       this.command = new CallbackCommand(commandOptions, this.wasmFs);
     }
+
+    this.wasmFs.volume.fds[0].node.read = this.stdinRead.bind(this);
+    this.wasmFs.volume.fds[1].node.write = this.stdoutWrite.bind(this);
+    this.wasmFs.volume.fds[2].node.write = this.stdoutWrite.bind(this);
+    const ttyFd = this.wasmFs.volume.openSync("/dev/tty", "w+");
+    this.wasmFs.volume.fds[ttyFd].node.read = this.stdinRead.bind(this);
+    this.wasmFs.volume.fds[ttyFd].node.write = this.stdoutWrite.bind(this);
+
+    this.sharedStdin = sharedStdin;
+    this.startStdinReadCallback = startStdinReadCallback;
+    this.readStdinCounter = 0;
+    this.pipedStdin = "";
   }
 
   async start(pipedStdinData?: Uint8Array) {
@@ -61,6 +101,10 @@ export default class Process {
     };
 
     try {
+      this.stdoutCallback = this.dataCallback;
+      if (pipedStdinData) {
+        this.pipedStdin = new TextDecoder("utf-8").decode(pipedStdinData);
+      }
       await this.command.run(pipedStdinData, this.dataCallback);
       end();
     } catch (e) {
@@ -83,5 +127,90 @@ export default class Process {
       console.error(e);
       this.errorCallback(error, this.wasmFs.toJSON());
     }
+  }
+
+  stdoutWrite(
+    stdoutBuffer: Buffer | Uint8Array,
+    offset: number = 0,
+    length: number = stdoutBuffer.byteLength,
+    position?: number
+  ) {
+    if (this.stdoutCallback) {
+      this.stdoutCallback(stdoutBuffer);
+    }
+    let dataLines = new TextDecoder("utf-8").decode(stdoutBuffer).split("\n");
+    if (dataLines.length > 0) {
+      this.stdinPrompt = cleanStdout(dataLines[dataLines.length - 1]);
+    } else {
+      this.stdinPrompt = "";
+    }
+    return stdoutBuffer.length;
+  }
+
+  // Handle read of stdin, similar to C read
+  // https://linux.die.net/man/2/read
+  // This is the bottom of the "layers stack". This is the outer binding.
+  // This is the the thing that returns -1 because it is the actual file system,
+  // but it is up to WASI lib  (wasi.ts) to find out why this error'd
+  stdinRead(
+    stdinBuffer: Buffer | Uint8Array,
+    offset: number = 0,
+    length: number = stdinBuffer.byteLength,
+    position?: number
+  ) {
+    if (this.readStdinCounter > 0) {
+      this.readStdinCounter--;
+      return 0;
+    }
+    this.readStdinCounter = 1;
+
+    let responseStdin: string | null = null;
+    if (this.pipedStdin) {
+      responseStdin = this.pipedStdin;
+      this.pipedStdin = "";
+      this.readStdinCounter++;
+    } else if (this.sharedStdin && this.startStdinReadCallback) {
+      this.startStdinReadCallback();
+      Atomics.wait(this.sharedStdin, 0, -1);
+
+      // Grab the of elements
+      const numberOfElements = this.sharedStdin[0];
+      this.sharedStdin[0] = -1;
+      const newStdinData = new Uint8Array(numberOfElements);
+      for (let i = 0; i < numberOfElements; i++) {
+        newStdinData[i] = this.sharedStdin[1 + i];
+      }
+      responseStdin = new TextDecoder("utf-8").decode(newStdinData);
+    } else {
+      responseStdin = prompt(
+        `Please enter text for stdin:\n${this.stdinPrompt}`
+      );
+      if (responseStdin === null) {
+        if (this.stdoutCallback) {
+          this.stdoutCallback(new TextEncoder().encode("\n"));
+        }
+        const userError = new Error("Process killed by user");
+        (userError as any).user = true;
+        throw userError;
+        return -1;
+      }
+      responseStdin += "\n";
+      if (this.stdoutCallback) {
+        this.stdoutCallback(new TextEncoder().encode(responseStdin));
+      }
+    }
+
+    // First check for errors
+    if (!responseStdin) {
+      return 0;
+    }
+
+    const buffer = new TextEncoder().encode(responseStdin);
+    for (let x = 0; x < buffer.length; ++x) {
+      stdinBuffer[x] = buffer[x];
+    }
+
+    // Return the current stdin
+    return buffer.length;
   }
 }


### PR DESCRIPTION
This PR:
* Unifies the `CallbackCommand` and `WASICommand` into a simpler `Command` interface
* Fixes error handling in `WASICommand`
* Moves the `WASICommand` logic to `Process`
* Removes unused `Duplex`
* Improves the `CallbackCommand` API so it can request the fs stdin if needed (as binary, not text)
* Fixes a "\n" appended when chaining callback commands

See simplified command source here: https://github.com/wasmerio/wasmer-js/tree/refactor-command/packages/wasm-terminal/src/command

Complex source (as in master): https://github.com/wasmerio/wasmer-js/tree/master/packages/wasm-terminal/src/command