### PR TITLE
Fixed the browser field per webpack bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2762,8 +2762,8 @@
     "@wasmer/wasm-terminal": {
       "version": "file:packages/wasm-terminal",
       "requires": {
-        "@wasmer/wasi": "^0.3.1",
-        "@wasmer/wasmfs": "^0.3.1",
+        "@wasmer/wasi": "^0.4.5",
+        "@wasmer/wasmfs": "^0.4.5",
         "comlink": "^4.0.5",
         "shell-parse": "0.0.2",
         "shell-quote": "^1.7.1",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -353,7 +353,9 @@
       "dev": true
     },
     "@wasmer/wasi": {
-      "version": "0.3.2",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-0.4.5.tgz",
+      "integrity": "sha512-dOt+Zj6vOk1C+1O+6aduKQgCy5VHZE20d14stGOFY0qPptJB8f4tfLWvd/NY/AK6hhSB8zFDV6rn1VowdiqYdw==",
       "requires": {
         "browser-process-hrtime": "^1.0.0",
         "buffer-es6": "^4.9.3",
@@ -362,7 +364,9 @@
       }
     },
     "@wasmer/wasm-transformer": {
-      "version": "0.3.2"
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasm-transformer/-/wasm-transformer-0.4.5.tgz",
+      "integrity": "sha512-GIOzar8FuO0yc6+tQA9qovOw0PO4btI2Gm+/gjQ1kVJEPaX4YHJAo8PtSoy+4NFmcoBIpY5ko7DC18zJrgxUqw=="
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -471,6 +475,11 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -487,6 +496,11 @@
         "electron-to-chromium": "^1.3.295",
         "node-releases": "^1.1.38"
       }
+    },
+    "buffer-es6": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/buffer-es6/-/buffer-es6-4.9.3.tgz",
+      "integrity": "sha1-8mNHuC33b9N+GLy1KIxJcM/VxAQ="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -2065,6 +2079,11 @@
         "cross-spawn": "^6.0.5"
       }
     },
+    "path-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz",
+      "integrity": "sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g=="
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2176,6 +2195,23 @@
             "universalify": "^0.1.0"
           }
         }
+      }
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "requires": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "read-pkg": {
@@ -2362,8 +2398,7 @@
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-      "dev": true
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "semver": {
       "version": "5.7.1",

--- a/packages/wasi/package.json
+++ b/packages/wasi/package.json
@@ -4,7 +4,7 @@
   "description": "Isomorphic Javascript library for interacting with WASI Modules in Node.js and the Browser. 📚",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
-  "browser": "lib/index.iife.js",
+  "iife": "lib/index.iife.js",
   "typings": "lib/wasi/src/index.d.ts",
   "files": [
     "lib"

--- a/packages/wasi/rollup.config.js
+++ b/packages/wasi/rollup.config.js
@@ -63,7 +63,7 @@ const libBundles = [
   {
     input: "./src/index.ts",
     output: {
-      file: pkg.browser,
+      file: pkg.iife,
       format: "iife",
       sourcemap: sourcemapOption,
       name: "WASI"

--- a/packages/wasm-terminal/package-lock.json
+++ b/packages/wasm-terminal/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@wasmer/wasi": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-0.3.2.tgz",
-      "integrity": "sha512-ndCugkC6/gbr7HDz8rjVJ8jvuKDf5DtjyQPrNSX/4TBXUHYmugleksnvLk4oj3nL9mkKG7+mN6n8CUawJuj4xQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasi/-/wasi-0.4.5.tgz",
+      "integrity": "sha512-dOt+Zj6vOk1C+1O+6aduKQgCy5VHZE20d14stGOFY0qPptJB8f4tfLWvd/NY/AK6hhSB8zFDV6rn1VowdiqYdw==",
       "requires": {
         "browser-process-hrtime": "^1.0.0",
         "buffer-es6": "^4.9.3",
@@ -16,9 +16,9 @@
       }
     },
     "@wasmer/wasmfs": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wasmer/wasmfs/-/wasmfs-0.3.2.tgz",
-      "integrity": "sha512-ggPC66XPnlOwVeFUGEvd9WqOCRb1DdnDuo7nrAhSKowuCksZfIFHkCuzO8272q/gWkPMxsRpxULd9UKJwoyhZg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@wasmer/wasmfs/-/wasmfs-0.4.5.tgz",
+      "integrity": "sha512-rsUQ/BP4T+TGBhQbZ97QVwSNFsPPeSIy2PYhfae4mwPjNPqqh1s117QpoybuTRUV5oOWGQX5JiG5JqVEcaUlcw==",
       "requires": {
         "memfs": "git+https://github.com/torch2424/memfs.git#wasmfs-fixes"
       }

--- a/packages/wasm-terminal/package.json
+++ b/packages/wasm-terminal/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.5",
   "description": "A terminal-like component for the browser, that fetches and runs Wasm modules in the context of a shell. 🐚",
   "module": "lib/unoptimized/wasm-terminal.esm.js",
-  "browser": "lib/unoptimized/wasm-terminal.iife.js",
+  "iife": "lib/unoptimized/wasm-terminal.iife.js",
   "typings": "lib/wasm-terminal/src/index.d.ts",
   "files": [
     "lib"

--- a/packages/wasm-transformer/package.json
+++ b/packages/wasm-transformer/package.json
@@ -4,7 +4,7 @@
   "description": "Library to run transformations on WebAssembly binaries. 🦀♻️",
   "main": "lib/wasm-pack/node/wasm_transformer.js",
   "module": "lib/unoptimized/wasm-transformer.esm.js",
-  "browser": "lib/unoptimized/wasm-transformer.iife.js",
+  "iife": "lib/unoptimized/wasm-transformer.iife.js",
   "typings": "lib/unoptimized/wasm-transformer/src/unoptimized.d.ts",
   "files": [
     "lib"

--- a/packages/wasmfs/package.json
+++ b/packages/wasmfs/package.json
@@ -4,7 +4,7 @@
   "description": "Isomorphic library to provide a sandboxed node fs implementation for Node and Browsers. 📂",
   "main": "lib/index.cjs.js",
   "module": "lib/index.esm.js",
-  "browser": "lib/index.iife.js",
+  "iife": "lib/index.iife.js",
   "typings": "lib/wasmfs/src/index.d.ts",
   "files": [
     "lib"

--- a/packages/wasmfs/rollup.config.js
+++ b/packages/wasmfs/rollup.config.js
@@ -46,7 +46,7 @@ const fileSystemBundles = [
         sourcemap: sourcemapOption
       },
       {
-        file: pkg.browser,
+        file: pkg.iife,
         format: "iife",
         sourcemap: sourcemapOption,
         name: "WasmFs"


### PR DESCRIPTION
closes #155

Webpack has some odd behavior in handling the "browser" field: https://github.com/webpack/webpack/issues/4674 , Thus I went ahead and changed our iife builds meant for running standalone to the browser, to an iife key, similar to [WasmBoy](https://unpkg.com/browse/wasmboy@0.5.0/package.json)

# Example

![Screen Shot 2019-11-05 at 11 49 06 AM](https://user-images.githubusercontent.com/1448289/68240763-510c2700-ffc2-11e9-99ae-82d31a2f02a3.png)
![Screen Shot 2019-11-05 at 11 48 51 AM](https://user-images.githubusercontent.com/1448289/68240764-51a4bd80-ffc2-11e9-9350-e2f37402c76c.png)
