### PR TITLE
Wasi fixes extended

### DIFF
--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -148,6 +148,10 @@ const wrap = <T extends Function>(f: T) => (...args: any[]) => {
   try {
     return f(...args);
   } catch (e) {
+    // If it's an error from the fs
+    if (e && e.code && typeof e.code === "string") {
+      return ERROR_MAP[e.code] || WASI_EINVAL;
+    }
     // If it's a WASI error, we return it directly
     if (e instanceof WASIError) {
       return e.errno;
@@ -300,11 +304,8 @@ export type WASIConfig = {
 
 export class WASIError extends Error {
   errno: number;
-  constructor(errno: string | number) {
+  constructor(errno: number) {
     super();
-    if (typeof errno === "string") {
-      errno = ERROR_MAP[errno] || WASI_EINVAL;
-    }
     this.errno = errno;
   }
 }

--- a/packages/wasi/src/polyfills/browser-hrtime.ts
+++ b/packages/wasi/src/polyfills/browser-hrtime.ts
@@ -18,6 +18,5 @@ export default function hrtime(previousTimestamp: any) {
     }
   }
   // Return our seconds tuple
-
   return [seconds, nanoseconds];
 }

--- a/packages/wasi/src/polyfills/browser-hrtime.ts
+++ b/packages/wasi/src/polyfills/browser-hrtime.ts
@@ -1,9 +1,11 @@
 // hrtime polyfill for the browser
 
+const baseNow = Math.floor((Date.now() - performance.now()) * 1e-3);
+
 export default function hrtime(previousTimestamp: any) {
   // initilaize our variables
   let clocktime = performance.now() * 1e-3;
-  let seconds = Math.floor(clocktime);
+  let seconds = Math.floor(clocktime) + baseNow;
   let nanoseconds = Math.floor((clocktime % 1) * 1e9);
 
   // Compare to the prvious timestamp if we have one
@@ -15,7 +17,7 @@ export default function hrtime(previousTimestamp: any) {
       nanoseconds += 1e9;
     }
   }
-
   // Return our seconds tuple
+
   return [seconds, nanoseconds];
 }

--- a/packages/wasi/src/polyfills/hrtime.bigint.ts
+++ b/packages/wasi/src/polyfills/hrtime.bigint.ts
@@ -6,10 +6,8 @@ import { BigIntPolyfillType } from "./bigint";
 const NS_PER_SEC: number = 1e9;
 
 const getBigIntHrtime = (nativeHrtime: Function) => {
-  const baseTime: [number, number] = nativeHrtime();
   return (time?: [number, number]) => {
-    const diff = nativeHrtime(time || baseTime);
-
+    const diff = nativeHrtime(time);
     // Return the time
     return ((diff[0] * NS_PER_SEC + diff[1]) as unknown) as BigIntPolyfillType;
   };

--- a/packages/wasm-terminal/src/process/process.ts
+++ b/packages/wasm-terminal/src/process/process.ts
@@ -156,11 +156,10 @@ export default class Process {
     length: number = stdinBuffer.byteLength,
     position?: number
   ) {
-    if (this.readStdinCounter > 0) {
-      this.readStdinCounter--;
+    if (this.readStdinCounter % 2 !== 0) {
+      this.readStdinCounter++;
       return 0;
     }
-    this.readStdinCounter = 1;
 
     let responseStdin: string | null = null;
     if (this.pipedStdin) {

--- a/packages/wasm-terminal/src/process/process.ts
+++ b/packages/wasm-terminal/src/process/process.ts
@@ -1,4 +1,5 @@
 import { WasmFs } from "@wasmer/wasmfs";
+import { WASIExitError } from "@wasmer/wasi";
 
 import CommandOptions from "../command/command-options";
 import Command from "../command/command";
@@ -105,8 +106,8 @@ export default class Process {
       await this.command.run(this.wasmFs);
       end();
     } catch (e) {
-      if (e.code === 0) {
-        // Command was successful, but ended early.
+      if (e instanceof WASIExitError) {
+        const exitCode = e.code;
         end();
         // Set timeout to allow any lingering data callback to be launched out
         return;


### PR DESCRIPTION
This PR:
* [x] Fixes browser hrTime to return absolute time (not just relative to browser) - you can now run `$ cal` in the shell, and see the correct time.
* [x] Simplifies WASI error wrapping (making it more optimal)
* [x] Fixes stdin for some programs (`openssl` and `rustpython` were not working)