### PR TITLE
Fixed TS WASIError casting

### DIFF
--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -307,6 +307,7 @@ export class WASIError extends Error {
   constructor(errno: number) {
     super();
     this.errno = errno;
+    Object.setPrototypeOf(this, WASIError.prototype);
   }
 }
 
@@ -315,6 +316,7 @@ export class WASIExitError extends Error {
   constructor(code: number | null) {
     super(`WASI Exit error: ${code}`);
     this.code = code;
+    Object.setPrototypeOf(this, WASIExitError.prototype);
   }
 }
 
@@ -323,6 +325,7 @@ export class WASIKillError extends Error {
   constructor(signal: string) {
     super(`WASI Kill signal: ${signal}`);
     this.signal = signal;
+    Object.setPrototypeOf(this, WASIKillError.prototype);
   }
 }
 


### PR DESCRIPTION
Typescript2 feature when extending base class like Error it loses type binding when transpiled to ES5, hence in a wrap function following check never matches https://github.com/wasmerio/wasmer-js/blob/master/packages/wasi/src/index.ts#L156. 

This PR fixes issue according to TypeScript recommendation:
https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work