### PR TITLE
Dataview BigInt polyfill Should store and return same bigint value

### DIFF
--- a/packages/wasi/src/polyfills/dataview.ts
+++ b/packages/wasi/src/polyfills/dataview.ts
@@ -1,7 +1,7 @@
 // A very simple workaround for Big int. Works in conjunction with our custom
 // BigInt workaround at ./bigint.ts
 
-import { BigIntPolyfillType } from "./bigint";
+import { BigIntPolyfill as BigInt, BigIntPolyfillType } from "./bigint";
 
 let exportedDataView: any = DataView;
 
@@ -37,16 +37,15 @@ if (!exportedDataView.prototype.setBigUint64) {
   exportedDataView.prototype.getBigUint64 = function(
     byteOffset: number,
     littleEndian: boolean | undefined
-  ): number {
+  ) {
     let lowWord = this.getUint32(
       byteOffset + (littleEndian ? 0 : 4),
       littleEndian
     );
-    let highWord = this.setUint32(
+    let highWord = this.getUint32(
       byteOffset + (littleEndian ? 4 : 0),
       littleEndian
     );
-
     var lowWordAsBinaryStr = lowWord.toString(2);
     var highWordAsBinaryStr = lowWord.toString(2);
     // Convert the above binary str to 64 bit (actually 52 bit will work) by padding zeros in the left
@@ -55,7 +54,7 @@ if (!exportedDataView.prototype.setBigUint64) {
       lowWordAsBinaryStrPadded += "0";
     }
     lowWordAsBinaryStrPadded += lowWordAsBinaryStr;
-    return parseInt(highWordAsBinaryStr + lowWordAsBinaryStr);
+    return BigInt("0b" + highWordAsBinaryStr + lowWordAsBinaryStrPadded);
   };
 }
 

--- a/packages/wasi/src/polyfills/dataview.ts
+++ b/packages/wasi/src/polyfills/dataview.ts
@@ -26,8 +26,8 @@ if (!exportedDataView.prototype.setBigUint64) {
         bigNumberAsBinaryStr2 += "0";
       }
       bigNumberAsBinaryStr2 += bigNumberAsBinaryStr;
-      lowWord = parseInt(bigNumberAsBinaryStr2.substring(0, 32), 2);
-      highWord = parseInt(bigNumberAsBinaryStr2.substring(32), 2);
+      highWord = parseInt(bigNumberAsBinaryStr2.substring(0, 32), 2);
+      lowWord = parseInt(bigNumberAsBinaryStr2.substring(32), 2);
     }
 
     this.setUint32(byteOffset + (littleEndian ? 0 : 4), lowWord, littleEndian);

--- a/packages/wasi/src/polyfills/dataview.ts
+++ b/packages/wasi/src/polyfills/dataview.ts
@@ -47,7 +47,7 @@ if (!exportedDataView.prototype.setBigUint64) {
       littleEndian
     );
     var lowWordAsBinaryStr = lowWord.toString(2);
-    var highWordAsBinaryStr = lowWord.toString(2);
+    var highWordAsBinaryStr = highWord.toString(2);
     // Convert the above binary str to 64 bit (actually 52 bit will work) by padding zeros in the left
     var lowWordAsBinaryStrPadded = "";
     for (var i = 0; i < 32 - lowWordAsBinaryStr.length; i++) {

--- a/packages/wasi/test/dataview.polyfill.test.ts
+++ b/packages/wasi/test/dataview.polyfill.test.ts
@@ -12,8 +12,8 @@ describe("dataview Polyfill", () => {
       DataViewPolyfillType
     } = require("../src/polyfills/dataview");
     let buffer = new DataViewPolyfill(new ArrayBuffer(16));
-    const val = BigInt(2 ** 32 + 1);
+    const val = BigInt(2 ** 32 + 999666);
     buffer.setBigUint64(0, val, true);
-    expect(buffer.getBigUint64(0, true)).toEqual(val);
+    expect(buffer.getBigUint64(0, true).toString()).toEqual(val.toString());
   });
 });

--- a/packages/wasi/test/dataview.polyfill.test.ts
+++ b/packages/wasi/test/dataview.polyfill.test.ts
@@ -1,0 +1,16 @@
+import { BigIntPolyfillType } from "../src/polyfills/bigint";
+
+describe("dataview Polyfill", () => {
+  it("Should store and return same bigint value", () => {
+    DataView.prototype.setBigUint64 = undefined;
+    DataView.prototype.getBigUint64 = undefined;
+    let {
+      DataViewPolyfill,
+      DataViewPolyfillType
+    } = require("../src/polyfills/dataview");
+    let buffer = new DataViewPolyfill(new ArrayBuffer(16));
+    const val = ((2 ** 32 + 1) as unknown) as BigIntPolyfillType;
+    buffer.setBigUint64(0, val, true);
+    expect(buffer.getBigUint64(0, true)).toEqual(val);
+  });
+});

--- a/packages/wasi/test/dataview.polyfill.test.ts
+++ b/packages/wasi/test/dataview.polyfill.test.ts
@@ -4,16 +4,23 @@ import {
 } from "../src/polyfills/bigint";
 
 describe("dataview Polyfill", () => {
-  it("Should store and return same bigint value", () => {
-    DataView.prototype.setBigUint64 = undefined;
-    DataView.prototype.getBigUint64 = undefined;
-    let {
-      DataViewPolyfill,
-      DataViewPolyfillType
-    } = require("../src/polyfills/dataview");
+  DataView.prototype.setBigUint64 = undefined;
+  DataView.prototype.getBigUint64 = undefined;
+  let {
+    DataViewPolyfill,
+    DataViewPolyfillType
+  } = require("../src/polyfills/dataview");
+
+  it("Should store and return same bigint value little-endian", async () => {
     let buffer = new DataViewPolyfill(new ArrayBuffer(16));
     const val = BigInt(2 ** 32 + 999666);
     buffer.setBigUint64(0, val, true);
     expect(buffer.getBigUint64(0, true).toString()).toEqual(val.toString());
+  });
+  it("Should store and return same bigint value big-endian", async () => {
+    let buffer = new DataViewPolyfill(new ArrayBuffer(16));
+    const val = BigInt(2 ** 32 + 999666);
+    buffer.setBigUint64(0, val, false);
+    expect(buffer.getBigUint64(0, false).toString()).toEqual(val.toString());
   });
 });

--- a/packages/wasi/test/dataview.polyfill.test.ts
+++ b/packages/wasi/test/dataview.polyfill.test.ts
@@ -1,4 +1,7 @@
-import { BigIntPolyfillType } from "../src/polyfills/bigint";
+import {
+  BigIntPolyfill as BigInt,
+  BigIntPolyfillType
+} from "../src/polyfills/bigint";
 
 describe("dataview Polyfill", () => {
   it("Should store and return same bigint value", () => {
@@ -9,7 +12,7 @@ describe("dataview Polyfill", () => {
       DataViewPolyfillType
     } = require("../src/polyfills/dataview");
     let buffer = new DataViewPolyfill(new ArrayBuffer(16));
-    const val = ((2 ** 32 + 1) as unknown) as BigIntPolyfillType;
+    const val = BigInt(2 ** 32 + 1);
     buffer.setBigUint64(0, val, true);
     expect(buffer.getBigUint64(0, true)).toEqual(val);
   });


### PR DESCRIPTION
DataViewPolyfill for BigInt values does not seem to work on Safari, where custom implementation of setBigUint64 and getBigUint64 used. Below is a test result before
```
 ● dataview Polyfill › Should store and return same bigint value

    expect(received).toEqual(expected) // deep equality

    Expected: 4294967297
    Received: 11

       9 |     const val = ((2 ** 32 + 1) as unknown) as BigIntPolyfillType;
      10 |     buffer.setBigUint64(0, val, true);
    > 11 |     expect(buffer.getBigUint64(0, true)).toEqual(val);
```

- [X] Add tests for dataview bigint polyfill
- [X] Fix implementation

It should be working now, ready for review
