### PR TITLE
Add mapping to --dir option

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -18,8 +18,8 @@ hello world
 
   public static flags = {
     dir: flags.string({ multiple: true }),
-    mapdir: flags.string({ multiple: true }),
-    help: flags.help({ char: "h" })
+    help: flags.help({ char: "h" }),
+    mapdir: flags.string({ multiple: true })
   };
 
   public static args = [{ name: "file" }];

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -18,6 +18,7 @@ hello world
 
   public static flags = {
     dir: flags.string({ multiple: true }),
+    mapdir: flags.string({ multiple: true }),
     help: flags.help({ char: "h" })
   };
 
@@ -28,8 +29,18 @@ hello world
     const preopenDirectories: { [key: string]: string } = {};
     if (flags.dir) {
       flags.dir.forEach(dir => {
-        let [wasm, host] = dir.split("::");
-        preopenDirectories[wasm] = host || wasm;
+        preopenDirectories[dir] = dir;
+      });
+    }
+    if (flags.mapdir) {
+      flags.mapdir.forEach(dir => {
+        const [wasm, host] = dir.split(":");
+        if (!wasm || !host) {
+          this.error(
+            "Options to --mapdir= need to be in the format wasmDir:hostDir"
+          );
+        }
+        preopenDirectories[wasm] = host;
       });
     }
     let wasiArgs = this.argv.filter((arg: string) => {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -28,7 +28,8 @@ hello world
     const preopenDirectories: { [key: string]: string } = {};
     if (flags.dir) {
       flags.dir.forEach(dir => {
-        preopenDirectories[dir] = dir;
+        let [wasm, host] = dir.split("::");
+        preopenDirectories[wasm] = host || wasm;
       });
     }
     let wasiArgs = this.argv.filter((arg: string) => {


### PR DESCRIPTION
Make it possible to provide a mapping using the dir option: `wasmer-js run test.wasm --dir=/::/some/host/folder`. Or should this be a different flag (`--mapdir`?)