### PR TITLE
Wasi fixes

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,7 +22,7 @@ $ npm install -g @wasmer/cli
 $ wasmer-js COMMAND
 running command...
 $ wasmer-js (-v|--version|version)
-@wasmer/cli/0.5.1 darwin-x64 node-v10.16.3
+@wasmer/cli/0.5.1 darwin-x64 node-v12.6.0
 $ wasmer-js --help [COMMAND]
 USAGE
   $ wasmer-js COMMAND
@@ -64,8 +64,9 @@ USAGE
   $ wasmer-js run [FILE]
 
 OPTIONS
-  -h, --help  show CLI help
+  -h, --help       show CLI help
   --dir=dir
+  --mapdir=mapdir
 
 EXAMPLE
   $ wasmer-js run hello.wasm

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -26,10 +26,10 @@ hello world
 
   public async run() {
     const { args, flags } = this.parse(Run);
-    const preopenDirectories: { [key: string]: string } = {};
+    const preopens: { [key: string]: string } = {};
     if (flags.dir) {
       flags.dir.forEach(dir => {
-        preopenDirectories[dir] = dir;
+        preopens[dir] = dir;
       });
     }
     if (flags.mapdir) {
@@ -40,7 +40,7 @@ hello world
             "Options to --mapdir= need to be in the format wasmDir:hostDir"
           );
         }
-        preopenDirectories[wasm] = host;
+        preopens[wasm] = host;
       });
     }
     let wasiArgs = this.argv.filter((arg: string) => {
@@ -64,7 +64,7 @@ hello world
         fs
       },
       env: {},
-      preopenDirectories
+      preopens
     });
 
     const wasmBytes = fs.readFileSync(args.file);

--- a/packages/wasi/README.md
+++ b/packages/wasi/README.md
@@ -84,7 +84,7 @@ The Config object is is as follows:
 ```js
 let myWASIInstance = new WASI({
   // OPTIONAL: The pre-opened dirctories
-  preopenDirectories: {},
+  preopens: {},
 
   // OPTIONAL: The environment vars
   env: {},
@@ -137,7 +137,7 @@ The [default bindings](./lib/bindings) for the environment that are set on the `
 const myFs = require("fs");
 
 let wasi = new WASI({
-  preopenDirectories: {},
+  preopens: {},
   env: {},
   args: [],
   bindings: {

--- a/packages/wasi/test/wasi.test.ts
+++ b/packages/wasi/test/wasi.test.ts
@@ -71,7 +71,7 @@ const instantiateWASI = async (
   env: { [key: string]: string } = {}
 ) => {
   let wasi = new WASI({
-    preopenDirectories: {
+    preopens: {
       "/sandbox": "/sandbox"
     },
     env: env,

--- a/packages/wasm-terminal/src/command/wasi-command.ts
+++ b/packages/wasm-terminal/src/command/wasi-command.ts
@@ -16,7 +16,7 @@ export default class WASICommand extends Command {
 
   async run(wasmFs: WasmFs) {
     const wasi = new WASI({
-      preopenDirectories: {
+      preopens: {
         "/": "/"
       },
       env: this.options.env,


### PR DESCRIPTION
This PR:
* [x] Updates the WASI API to use `preopens` instead of `preopenDirs` (but still supporting old api);