### PR TITLE
Added links to the Wasmer Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Wasmer-JS is a mono-repo of multiple JavaScript packages enabling easy use of [W
 
 - [`@wasmer/wasm-terminal`](./packages/wasm-terminal) - A browser terminal/shell for interacting with WASI/Wasm Modules. It powers [WebAssembly.sh](https://webassembly.sh/).
 
+## Documentation
+
+Documentation for the Wasmer-JS Stack, can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+
 ## Development
 
 Contributing into Wasmer-JS it's very easy, just clone the repo and run:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -76,3 +76,7 @@ EXAMPLE
 _See code: [lib/commands/run.js](https://github.com/wasmerio/wasmer-js/blob/v0.6.0/lib/commands/run.js)_
 
 <!-- commandsstop -->
+
+# Documentation
+
+Documentation for `@wasmer/cli` can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/cli/wasmer-js-cli-installation).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -79,4 +79,4 @@ _See code: [lib/commands/run.js](https://github.com/wasmerio/wasmer-js/blob/v0.6
 
 # Documentation
 
-Documentation for `@wasmer/cli` can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/cli/wasmer-js-cli-installation).
+Documentation for `@wasmer/cli` can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,6 +6,8 @@ The CLI for executing Wasmer-JS
 [![Downloads/week](https://img.shields.io/npm/dw/@wasmer/cli.svg)](https://npmjs.org/package/@wasmer/cli)
 [![License](https://img.shields.io/npm/l/@wasmer/cli.svg)](https://github.com/wasmerio/wasmer-js/blob/master/package.json)
 
+Documentation for Wasmer-JS Stack can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+
 <!-- toc -->
 
 - [@wasmer/cli](#wasmercli)
@@ -76,7 +78,3 @@ EXAMPLE
 _See code: [lib/commands/run.js](https://github.com/wasmerio/wasmer-js/blob/v0.6.0/lib/commands/run.js)_
 
 <!-- commandsstop -->
-
-# Documentation
-
-Documentation for `@wasmer/cli` can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).

--- a/packages/io-devices/README.md
+++ b/packages/io-devices/README.md
@@ -2,6 +2,8 @@
 
 Isomorphic library to implement the experimental Wasmer I/O devices for the Wasmer-JS stack 🖼️🎮
 
+Documentation for Wasmer-JS Stack can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+
 ## Table of Contents
 
 - [Features](#features)
@@ -53,10 +55,6 @@ callbackCalled === true; // This should be true, our callback is called!
 ```
 
 `@wasmer/io-devices` is isomorphic, meaning this quick start should also work in Node with the appropriate Node syntax!
-
-## Documentation
-
-For documentation for this package, please see the [Wasmer-JS Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
 
 ## Contributing
 

--- a/packages/wasi/README.md
+++ b/packages/wasi/README.md
@@ -71,81 +71,9 @@ const startWasiTask = async () => {
 startWasiTask();
 ```
 
-For a larger end-to-end example, please see the [wasm-terminal package](https://github.com/wasmerio/wasmer-js/tree/master/packages/wasm-terminal).
+## Documentation
 
-## Reference API
-
-`new WASI(wasiConfigObject)`
-
-Constructs a new WASI instance.
-
-The Config object is is as follows:
-
-```js
-let myWASIInstance = new WASI({
-  // OPTIONAL: The pre-opened dirctories
-  preopens: {},
-
-  // OPTIONAL: The environment vars
-  env: {},
-
-  // OPTIONAL: The arguments provided
-  args: [],
-
-  // OPTIONAL: The environment bindings (fs, path),
-  // useful for using WASI in diferent environments
-  // such as Node.js, Browsers, ...
-  bindings: {
-    // hrtime: WASI.defaultConfig.bindings.hrtime,
-    // exit: WASI.defaultConfig.bindings.exit,
-    // kill: WASI.defaultConfig.bindings.kill,
-    // randomFillSync: WASI.defaultConfig.bindings.randomFillSync,
-    // isTTY: WASI.defaultConfig.bindings.isTTY,
-    // fs: WASI.defaultConfig.bindings.fs,
-    // path: WASI.defaultConfig.bindings.path,
-    ...WASI.defaultConfig.bindings
-  }
-});
-```
-
-And returns a WASI Instance:
-
-```js
-console.log(myWASIInstance);
-/*
-
-Would Output:
-
-{
-  memory: WebAssembly.Memory;
-  view: DataView;
-  FD_MAP: Map<number, File>;
-  exports: Exports; // WASI API to be imported in the importObject on instantiation.
-  bindings: WASIBindings;
-  start: (wasmInstance: WebAssembly.Instance) => void; // Function that takes in a WASI WebAssembly Instance and starts it.
-}
-*/
-```
-
----
-
-`WASI.defaultBindings`
-
-The [default bindings](./lib/bindings) for the environment that are set on the `bindings` property of the constructor config object. This is useful for use cases like, you want to plugin in your own file system. For example:
-
-```js
-const myFs = require("fs");
-
-let wasi = new WASI({
-  preopens: {},
-  env: {},
-  args: [],
-  bindings: {
-    fs: myFs,
-    ...WASI.defaultBindings
-  }
-});
-```
+For documentation on `@wasmer/wasi`, such as additional examples and a Reference API. Please take a look at the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
 
 ## Contributing
 

--- a/packages/wasi/README.md
+++ b/packages/wasi/README.md
@@ -2,6 +2,8 @@
 
 Isomorphic Javascript library for interacting with WASI Modules in Node.js and the Browser. 📚
 
+Documentation for Wasmer-JS Stack can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+
 ## Table of Contents
 
 - [Features](#features)
@@ -71,9 +73,9 @@ const startWasiTask = async () => {
 startWasiTask();
 ```
 
-## Documentation
+## Reference API
 
-For documentation on `@wasmer/wasi`, such as additional examples and a Reference API. Please take a look at the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+The Reference API Documentation can be found on the [`@wasmer/wasi` Reference API Wasmer Docs](https://docs.wasmer.io/wasmer-js/reference-api/wasmer-js-reference-api-wasi).
 
 ## Contributing
 

--- a/packages/wasm-terminal/README.md
+++ b/packages/wasm-terminal/README.md
@@ -2,6 +2,8 @@
 
 A terminal-like component for the browser, that fetches and runs Wasm modules in the context of a shell. 🐚
 
+Documentation for Wasmer-JS Stack can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+
 ![Wasm Terminal Demo Gif](./assets/wasm-terminal-demo.gif)
 
 ## Table of Contents
@@ -160,9 +162,9 @@ wasmTerminal.focus();
 
 **NOTE:** Remember to include the CSS file mentioned at the beginning of the "Quick Start" section.
 
-## Documentation
+## Reference API
 
-For documentation on `@wasmer/wasm-terminal`, such as additional examples and a Reference API. Please take a look at the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+The Reference API Documentation can be found on the [`@wasmer/wasm-terminal` Reference API Wasmer Docs](https://docs.wasmer.io/wasmer-js/reference-api/wasmer-js-reference-api-wasm-terminal).
 
 ## Browser Compatibility
 

--- a/packages/wasm-terminal/README.md
+++ b/packages/wasm-terminal/README.md
@@ -103,7 +103,7 @@ wasmTerminal.focus();
 
 ### Optimized
 
-Optimized bundles, for both `@wasmer/wasm-terminal` and `@wasmer/wasm-transfoormer`, prioritize performance. For examples, assets required by the library must be passed in manually.
+Optimized bundles, for both `@wasmer/wasm-terminal` and `@wasmer/wasm-transformer`, prioritize performance. For examples, assets required by the library must be passed in manually.
 
 ```javascript
 import WasmTerminal, {
@@ -160,88 +160,9 @@ wasmTerminal.focus();
 
 **NOTE:** Remember to include the CSS file mentioned at the beginning of the "Quick Start" section.
 
-## Wasm Terminal Reference API
+## Documentation
 
-### WasmTerminal
-
-`new WasmTerminal(WasmTerminalConfig)`
-
-Constructor for the WasmTerminal, that returns an instance of the WasmTerminal.
-
-The [WasmTerminalConfig](./lib/wasm-terminal-config.ts) can be described as the following:
-
-```typescript
-{
-  // Function that is called whenever a command is entered and returns a Promise,
-  // It takes in the name of the command being run, and expects a Uint8Array of a Wasm Binary, or a
-  // CallbackCommand (see the api below) to be returned.
-  fetchCommand: (
-    commandName: string,
-    commandArgs?: Array<string>,
-    envEntries?: any[][]
-  ) => Promise<Uint8Array | CallbackCommand>
-  // Only for Optimized Bundles: URL to the /node_modules/wasm-terminal/workers/process.worker.js . This is used by the shell to
-  // to spawn web workers in Comlink, for features such as piping, /dev/stdin reading, and general performance enhancements.
-  processWorkerUrl?: string;
-}
-```
-
-CallbackCommands are functions that can be returned in the `fetchCommand` config property. They are simply Javascript callback that take in the command name, command arguments, enviroment variables, and returns a Promise that resolves stdout. Since these callback commands handle `stdin` and `stdout`, that can be used as normal commands that can be piped!
-
-```typescript
-export type CallbackCommand = (
-  options: CommandOptions,
-  wasmFs: WasmFs
-) => Promise<string | undefined> | string | undefined;
-```
-
----
-
-`wasmTerminal.open(containerElement: Element)`
-
-Function to set the container of the `wasmTerminal`. `containerElement` can be any [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element).
-
----
-
-`wasmTerminal.fit()`
-
-Function to resize the terminal to fit the size of its container.
-
----
-
-`wasmTerminal.focus()`
-
-Function to [focus](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) on the `wasmTerminal` element, and allow input into the shell.
-
----
-
-`wasmTerminal.print(message: string)`
-
-Function to print text to the wasmTerminal. Useful for printing a welcome message before the wasmTerminal is opened.
-
----
-
-`wasmTerminal.scrollToCursor()`
-
-Function to scroll the terminal cursor into view.
-
----
-
-`wasmTerminal.runCommand(commandString: string)`
-
-Function to run the passed string as if it was entered as a command, from the wasm terminal.
-
-### fetchCommandFromWAPM
-
-```typescript
-fetchCommandFromWAPM(
-  commandName: string,
-  commandArgs?: Array<string>,
-  envEntries?: any[][]
-) => Promise<Uint8Array>
-```
-
-Function meant to be returned in the `fetchCommand` config property of the WasmTerminal Class. This takes in the name of command, the command arguments, and the envioronment variables, and returns a Promise that resolves a Uint8Array of the Wasm binary from WAPM.
+For documentation on `@wasmer/wasm-terminal`, such as additional examples and a Reference API. Please take a look at the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
 
 ## Browser Compatibility
 

--- a/packages/wasm-transformer/README.md
+++ b/packages/wasm-transformer/README.md
@@ -2,6 +2,8 @@
 
 Library to run transformations on WebAssembly binaries. 🦀♻️
 
+Documentation for Wasmer-JS Stack can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+
 **This README covers the instructions for installing, using, and contributing to the `wasm-transformer` Javascript package. [The `wasm_transformer` Rust crate is available here](../../packages/wasm-transformer).**
 
 ## Table of Contents
@@ -109,9 +111,9 @@ const fetchAndTransformWasmBinary = async () => {
 };
 ```
 
-## Documentation
+## Reference API
 
-For documentation on `@wasmer/wasm-terminal`, such as additional examples and a Reference API. Please take a look at the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+The Reference API Documentation can be found on the [`@wasmer/wasm-transformer` Reference API Wasmer Docs](https://docs.wasmer.io/wasmer-js/reference-api/wasmer-js-reference-api-wasi).
 
 ## Contributing
 

--- a/packages/wasm-transformer/README.md
+++ b/packages/wasm-transformer/README.md
@@ -109,49 +109,9 @@ const fetchAndTransformWasmBinary = async () => {
 };
 ```
 
-## Reference API
+## Documentation
 
-### Node
-
-`version()`
-
-Returns the version of the package.
-
----
-
-`lowerI64Imports(wasmBinaryWithI64Imports: Uint8Array): Uint8Array`
-
-Inserts trampoline functions for imports that have i64 params or returns. This is useful for running Wasm modules in JS runtimes that [do not support JavaScript BigInt -> Wasm i64 integration](https://github.com/WebAssembly/proposals/issues/7). Especially in the case for [i64 WASI Imports](https://github.com/CraneStation/wasmtime/blob/master/docs/WASI-api.md#clock_time_get). Returns the lowered wasm binary as a Uint8Array.
-
-### Unoptimized Browser
-
-`version(): Promise<string>`
-
-Returns a promise that resolves the version of the package.
-
----
-
-`lowerI64Imports(wasmBinaryWithI64Imports: Uint8Array): Promise<Uint8Array>`
-
-Inserts trampoline functions for imports that have i64 params or returns. This is useful for running Wasm modules in JS runtimes that [do not support JavaScript BigInt -> Wasm i64 integration](https://github.com/WebAssembly/proposals/issues/7). Especially in the case for [i64 WASI Imports](https://github.com/CraneStation/wasmtime/blob/master/docs/WASI-api.md#clock_time_get). Returns a promise the resolves the lowered wasm binary as a Uint8Array.
-
-### Optimized Browser
-
-`wasmTransformerInit(wasmUrl: string): Promise`
-
-Initialzation function exported by `wasm-pack build`. This takes in a URL to where the `node_modules/@wasmer/wasm-transformer/wasm-transformer.wasm` is hosted.
-
----
-
-`version()`
-
-Returns the version of the package.
-
----
-
-`lowerI64Imports(wasmBinaryWithI64Imports: Uint8Array): Uint8Array`
-
-Inserts trampoline functions for imports that have i64 params or returns. This is useful for running Wasm modules in browsers that [do not support JavaScript BigInt -> Wasm i64 integration](https://github.com/WebAssembly/proposals/issues/7). Especially in the case for [i64 WASI Imports](https://github.com/CraneStation/wasmtime/blob/master/docs/WASI-api.md#clock_time_get). Returns the lowered wasm binary as a Uint8Array.
+For documentation on `@wasmer/wasm-terminal`, such as additional examples and a Reference API. Please take a look at the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
 
 ## Contributing
 

--- a/packages/wasmfs/README.md
+++ b/packages/wasmfs/README.md
@@ -43,35 +43,9 @@ wasmFs.getStdOut().then(response => {
 });
 ```
 
-For a larger end-to-end example, please see the [`@wasmer/wasm-terminal` package](https://github.com/wasmerio/wasmer-js/tree/master/packages/wasm-terminal).
+## Documentation
 
-## Reference API
-
-`wasmFs.fs`
-
-[memfs](https://github.com/streamich/memfs)' [node fs](https://nodejs.org/api/fs.html) implementation object. See the [node fs documentation](https://nodejs.org/api/fs.html) for API usage.
-
-**NOTE:** The functions on this `fs` implementation can easily be overriden to provide custom functionality when your wasm module (running with [`@wasmer/wasi`](https://github.com/wasmerio/wasmer-js/tree/master/packages/wasi)) tries to do file system operations. For example:
-
-```js
-const wasmFs = new WasmFs();
-
-const originalWriteFileSync = wasmFs.fs.writeFileSync;
-wasmFs.fs.writeFileSync = (path, text) => {
-  console.log("File written:", path);
-  originalWriteFileSync(path, text);
-};
-
-wasmFs.fs.writeFileSync("/dev/stdout", "Quick Start!");
-
-// Would log: "File written: /dev/stdout"
-```
-
----
-
-`wasmFs.getStdOut()`
-
-Function that returns a promise that resolves a string. With the file contents of `/dev/stdout`.
+For documentation on `@wasmer/wasm-terminal`, such as additional examples and a Reference API. Please take a look at the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
 
 ## Contributing
 

--- a/packages/wasmfs/README.md
+++ b/packages/wasmfs/README.md
@@ -2,6 +2,8 @@
 
 Isomorphic library to provide a sandboxed [node `fs`](https://nodejs.org/api/fs.html) implementation for Node and Browsers. 📂
 
+Documentation for Wasmer-JS Stack can be found on the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+
 ## Table of Contents
 
 - [Features](#features)
@@ -43,9 +45,9 @@ wasmFs.getStdOut().then(response => {
 });
 ```
 
-## Documentation
+## Reference API
 
-For documentation on `@wasmer/wasm-terminal`, such as additional examples and a Reference API. Please take a look at the [Wasmer Docs](https://docs.wasmer.io/wasmer-js/wasmer-js).
+The Reference API Documentation can be found on the [`@wasmer/wasmfs` Reference API Wasmer Docs](https://docs.wasmer.io/wasmer-js/reference-api/wasmer-js-reference-api-wasi).
 
 ## Contributing
 


### PR DESCRIPTION
Adds links to the Wasmer Docs. All packages, and the base README, offer quick examples, but then point to the docs for more advanced / larger project usage 😄 👍 