### PR TITLE
wasm-transformer: Added support for BigInt feature detection to optionally transform modules

### DIFF
--- a/3p-modules.d.ts
+++ b/3p-modules.d.ts
@@ -3,3 +3,4 @@ declare module "path-browserify";
 declare module "shell-parse";
 declare module "spyfs";
 declare module "sinon";
+declare module "wasm-feature-detect";

--- a/packages/wasm-transformer/package-lock.json
+++ b/packages/wasm-transformer/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "@wasmer/wasm-transformer",
   "version": "0.6.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "wasm-feature-detect": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.2.2.tgz",
+      "integrity": "sha512-fj8PiWfNux69j27u9wQgPzltip7WioDMjldbVb6JFvb2PnF2JvKN/PfFOkrhbg4RQo/+Q8ClcZI6vJMOCSQz+Q=="
+    }
+  }
 }

--- a/packages/wasm-transformer/package.json
+++ b/packages/wasm-transformer/package.json
@@ -26,5 +26,8 @@
     "url": "https://github.com/wasmerio/wasmer-js/issues"
   },
   "homepage": "https://github.com/wasmerio/wasmer-js#readme",
-  "gitHead": "889c22135c81610ddecbb696f8ef24f7ecaf5db7"
+  "gitHead": "889c22135c81610ddecbb696f8ef24f7ecaf5db7",
+  "dependencies": {
+    "wasm-feature-detect": "^1.2.2"
+  }
 }

--- a/packages/wasm-transformer/src/optimized.ts
+++ b/packages/wasm-transformer/src/optimized.ts
@@ -1,10 +1,25 @@
-export * from "../wasm-pack/web/wasm_transformer";
-
 // @ts-ignore
-import init from "../wasm-pack/web/wasm_transformer";
+import * as wasmTransformerWasmPack from "../wasm-pack/web/wasm_transformer";
+
+import { bigInt } from "wasm-feature-detect";
+
+let isBigIntSupported = false;
 
 export const wasmTransformerInit = async (passedWasmTransformerUrl: string) => {
-  await init(passedWasmTransformerUrl);
+  await wasmTransformerWasmPack.default(passedWasmTransformerUrl);
+  isBigIntSupported = await bigInt();
+};
+
+export const lowerI64Imports = (wasmBinary: Uint8Array) => {
+  if (isBigIntSupported) {
+    return wasmBinary;
+  }
+
+  return wasmTransformerWasmPack.lowerI64Imports(wasmBinary);
+};
+
+export const version = () => {
+  return wasmTransformerWasmPack.version();
 };
 
 export default wasmTransformerInit;

--- a/packages/wasm-transformer/src/unoptimized.ts
+++ b/packages/wasm-transformer/src/unoptimized.ts
@@ -10,7 +10,7 @@ import { bigInt } from "wasm-feature-detect";
 const initPromise = wasmTransformerWasmPack.default(wasmTransformerWasmUrl);
 
 export const lowerI64Imports = async (wasmBinary: Uint8Array) => {
-  let isBigIntSupported = bigInt();
+  let isBigIntSupported = await bigInt();
   if (isBigIntSupported) {
     return wasmBinary;
   }

--- a/packages/wasm-transformer/src/unoptimized.ts
+++ b/packages/wasm-transformer/src/unoptimized.ts
@@ -4,10 +4,17 @@ import wasmTransformerWasmUrl from "../wasm-pack/web/wasm_transformer_bg.wasm";
 // @ts-ignore
 import * as wasmTransformerWasmPack from "../wasm-pack/web/wasm_transformer";
 
+import { bigInt } from "wasm-feature-detect";
+
 // @ts-ignore
 const initPromise = wasmTransformerWasmPack.default(wasmTransformerWasmUrl);
 
 export const lowerI64Imports = async (wasmBinary: Uint8Array) => {
+  let isBigIntSupported = bigInt();
+  if (isBigIntSupported) {
+    return wasmBinary;
+  }
+
   await initPromise;
   return wasmTransformerWasmPack.lowerI64Imports(wasmBinary);
 };


### PR DESCRIPTION
closes #31 

This does bigInt feature detection, and only lowers i64 if it is needed 😄 

# Example

**Passes E2E tests 😄 **

<img width="328" alt="Screen Shot 2020-01-29 at 1 15 29 PM" src="https://user-images.githubusercontent.com/1448289/73397972-7050e280-4299-11ea-8c37-e5a6c2b44ae7.png">
