### PR TITLE
Fix wasm terminal terminal type exports

### DIFF
--- a/examples/wasm-shell/package.json
+++ b/examples/wasm-shell/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/wasmerio/wasmer-js/tree/master/examples/wasm-shell",
   "devDependencies": {
     "parcel-bundler": "^1.12.4",
-    "parcel-plugin-static-files-copy": "^2.2.1",
+    "parcel-plugin-static-files-copy": "^2.3.1",
     "typescript": "^3.6.4"
   },
   "browserslist": [

--- a/packages/wasm-terminal/package-lock.json
+++ b/packages/wasm-terminal/package-lock.json
@@ -19,7 +19,7 @@
     "@wasmer/wasmfs": {
       "version": "file:../wasmfs",
       "requires": {
-        "memfs": "^3.0.4"
+        "memfs": "3.0.4"
       }
     },
     "array-map": {

--- a/packages/wasm-terminal/package.json
+++ b/packages/wasm-terminal/package.json
@@ -4,7 +4,7 @@
   "description": "A terminal-like component for the browser, that fetches and runs Wasm modules in the context of a shell. 🐚",
   "module": "lib/unoptimized/wasm-terminal.esm.js",
   "iife": "lib/unoptimized/wasm-terminal.iife.js",
-  "typings": "lib/wasm-terminal/src/index.d.ts",
+  "typings": "lib/unoptimized/packages/wasm-terminal/src/index.d.ts",
   "files": [
     "lib"
   ],

--- a/packages/wasm-terminal/rollup.lib.js
+++ b/packages/wasm-terminal/rollup.lib.js
@@ -62,7 +62,11 @@ let plugins = [
   resolve({
     preferBuiltins: true
   }),
-  commonjs(),
+  commonjs({
+    namedExports: {
+      'xterm': ['Terminal']
+    }
+  }),
   globals(),
   builtins(),
   json(),

--- a/packages/wasm-terminal/rollup.lib.js
+++ b/packages/wasm-terminal/rollup.lib.js
@@ -64,7 +64,7 @@ let plugins = [
   }),
   commonjs({
     namedExports: {
-      'xterm': ['Terminal']
+      xterm: ["Terminal"]
     }
   }),
   globals(),

--- a/packages/wasmfs/package.json
+++ b/packages/wasmfs/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/wasmerio/wasmer-js/tree/master/packages/wasmfs",
   "dependencies": {
-    "memfs": "^3.0.4",
+    "memfs": "3.0.4",
     "pako": "^1.0.11",
     "tar-stream": "^2.1.0"
   },


### PR DESCRIPTION
If you try to do `import WasmTerminal from '@wasmer/wasm-terminal';` typescript would error saying module not found. This is due to to the typings path in package.json not matching what rollup was generating. I tried to fix it in rollup but I'm not too familiar with it so I didn't get anywhere.

I also noticed that in a newer version of memfs `TFilePath` was no longer exported so it was causing the build to fail so i locked it to `3.0.4`.

As an aside, is there a reason why the defaults in package.json is pointing at the unoptimized build instead of the optimized one? 