### PR TITLE
import path-browserify as cjs module

### DIFF
--- a/packages/wasi/src/bindings/browser.ts
+++ b/packages/wasi/src/bindings/browser.ts
@@ -2,7 +2,7 @@
 import * as randomfill from "randomfill";
 import hrtime from "../polyfills/browser-hrtime";
 // @ts-ignore
-import path from "path-browserify";
+import * as path from "path-browserify";
 
 import { WASIBindings, WASIExitError, WASIKillError } from "../index";
 import getBigIntHrtime from "../polyfills/hrtime.bigint";


### PR DESCRIPTION
The path module is imported as it has a default export, from the compiled ts code (bindings/browser.js) it's possible to see

```
const path_browserify_1 = require("path-browserify");
...
    // @ts-ignore
    randomFillSync: randomfill.randomFillSync,
    isTTY: () => true,
    path: path_browserify_1.default,
    // Let the user attach the fs at runtime
    fs: null
```

I know that it's possible in either tsconfig or webpack option to convert commonjs modules into es module. But in this particular case, it's probably easier to use the asterix.