### PR TITLE
Fix realtime clock; clock resolutions

### DIFF
--- a/packages/wasi/src/constants.ts
+++ b/packages/wasi/src/constants.ts
@@ -286,9 +286,9 @@ export const RIGHTS_TTY_BASE =
   WASI_RIGHT_POLL_FD_READWRITE;
 export const RIGHTS_TTY_INHERITING = BigInt(0);
 
-export const WASI_CLOCK_MONOTONIC = 0;
-export const WASI_CLOCK_PROCESS_CPUTIME_ID = 1;
-export const WASI_CLOCK_REALTIME = 2;
+export const WASI_CLOCK_REALTIME = 0;
+export const WASI_CLOCK_MONOTONIC = 1;
+export const WASI_CLOCK_PROCESS_CPUTIME_ID = 2;
 export const WASI_CLOCK_THREAD_CPUTIME_ID = 3;
 
 export const WASI_EVENTTYPE_CLOCK = 0;

--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -484,7 +484,6 @@ export default class WASIDefault {
     const now = (clockId: number) => {
       switch (clockId) {
         case WASI_CLOCK_MONOTONIC:
-        case WASI_CLOCK_REALTIME:
           return bindings.hrtime();
         case WASI_CLOCK_REALTIME:
           return msToNs(new Date().valueOf());
@@ -544,7 +543,20 @@ export default class WASIDefault {
         return WASI_ESUCCESS;
       },
       clock_res_get: (clockId: number, resolution: number) => {
-        this.view.setBigUint64(resolution, BigInt(0));
+        let res
+        switch (clockId) {
+          case WASI_CLOCK_MONOTONIC:
+          case WASI_CLOCK_PROCESS_CPUTIME_ID:
+          case WASI_CLOCK_THREAD_CPUTIME_ID: {
+            res = BigInt(1);
+            break;
+          }
+          case WASI_CLOCK_REALTIME: {
+            res = BigInt(1000);
+            break
+          }
+        }
+        this.view.setBigUint64(resolution, res);
         return WASI_ESUCCESS;
       },
       clock_time_get: (clockId: number, precision: number, time: number) => {

--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -486,6 +486,8 @@ export default class WASIDefault {
         case WASI_CLOCK_MONOTONIC:
         case WASI_CLOCK_REALTIME:
           return bindings.hrtime();
+        case WASI_CLOCK_REALTIME:
+          return msToNs(new Date().valueOf());
         case WASI_CLOCK_PROCESS_CPUTIME_ID:
         case WASI_CLOCK_THREAD_CPUTIME_ID:
           // return bindings.hrtime(CPUTIME_START)


### PR DESCRIPTION
Hi! I was using `clock_time_get` with the `REALTIME` clockid and noticed I was getting an odd value. It looks like all of the clocks were using `process.hrtime`, which was meant for performance testing rather than the current (wall) time.

From https://nodejs.org/api/process.html#process_process_hrtime_time:
> These times are relative to an arbitrary time in the past, and not related to the time of day and therefore not subject to clock drift. The primary use is for measuring performance between intervals

For some reason, those same Node docs do say 
> The process.hrtime() method returns the current high-resolution real time 

But I think that's a mistake. [The WASI spec](https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/witx/typenames.witx#L19) looks like it intends for the `REALTIME` clock to reference the wall clock, e.g. `new Date()`.

Once I did that, it seemed like the `clockid`s were misnumbered? I don't know if there are guidelines for how the enums are assigned values, but I figure it's just in the order listed in the spec. It looks like [that's what AssemblyScript does too](https://github.com/AssemblyScript/assemblyscript/blob/master/std/assembly/bindings/wasi_snapshot_preview1.ts#L610).

Finally, I updated `clock_res_get` to return the resolutions of the clocks— 1000 for `REALTIME` (since `new Date().valueOf()` is in milliseconds) and 1 for `MONOTONIC`, `PROCESS_CPUTIME_ID`, and `THREAD_CPUTIME_ID`.

Let me know if there's anything I can do to help this land!