### PR TITLE
[wasi] Have fd_fdstat_set_rights set permissions properly

### DIFF
--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -622,8 +622,8 @@ export default class WASIDefault {
           if (nri > stats.rights.inheriting) {
             return WASI_EPERM;
           }
-          stats.rights.base = nrb;
-          stats.rights.inheriting = nri;
+          stats.rights.base = fsRightsBase;
+          stats.rights.inheriting = fsRightsInheriting;
           return WASI_ESUCCESS;
         }
       ),


### PR DESCRIPTION
It looks like this check
```js
const nrb = stats.rights.base | fsRightsBase;
if (nrb > stats.rights.base) {
  return WASI_EPERM;
}
```
guarantees that you don't grant yourself more rights than you previously had, though then setting the permissions to `nrb` doesn't change anything since `a | b` when `(a | b) <= a` is just `a`.