### PR TITLE
[wasi] fd_filestat_get linkcount should be a u64

### DIFF
--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -636,9 +636,9 @@ export default class WASIDefault {
         this.view.setBigUint64(bufPtr, BigInt(rstats.ino), true);
         bufPtr += 8;
         this.view.setUint8(bufPtr, stats.filetype);
-        bufPtr += 4;
-        this.view.setUint32(bufPtr, Number(rstats.nlink), true);
-        bufPtr += 4;
+        bufPtr += 8;
+        this.view.setBigUint64(bufPtr, BigInt(rstats.nlink), true);
+        bufPtr += 8;
         this.view.setBigUint64(bufPtr, BigInt(rstats.size), true);
         bufPtr += 8;
         this.view.setBigUint64(bufPtr, msToNs(rstats.atimeMs), true);
@@ -646,7 +646,6 @@ export default class WASIDefault {
         this.view.setBigUint64(bufPtr, msToNs(rstats.mtimeMs), true);
         bufPtr += 8;
         this.view.setBigUint64(bufPtr, msToNs(rstats.ctimeMs), true);
-        bufPtr += 8;
         return WASI_ESUCCESS;
       }),
       fd_filestat_set_size: wrap((fd: number, stSize: number) => {


### PR DESCRIPTION
Looks like the linkcount in the struct [should be 64 bits wide](https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/witx/typenames.witx#L456).

I believe this is the correct alignment for this struct (i64's should be 8-byte aligned? maybe? unclear) but let me know if I'm wrong and it's supposed to be aligned to 4 bytes or something.