### PR TITLE
[wasi] fd/path_filestat_set_times - Only set times that are flagged, return WASI_EINVAL for invalid flags

### DIFF
--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -159,8 +159,8 @@ const STDERR_DEFAULT_RIGHTS = STDOUT_DEFAULT_RIGHTS;
 
 const msToNs = (ms: number) => {
   const msInt = Math.trunc(ms);
-  const decimal = BigInt(Math.round((ms - msInt) * 1000));
-  const ns = BigInt(msInt) * BigInt(1000);
+  const decimal = BigInt(Math.round((ms - msInt) * 1000000));
+  const ns = BigInt(msInt) * BigInt(1000000);
   return ns + decimal;
 };
 

--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -668,8 +668,8 @@ export default class WASIDefault {
         (fd: number, stAtim: number, stMtim: number, fstflags: number) => {
           const stats = CHECK_FD(fd, WASI_RIGHT_FD_FILESTAT_SET_TIMES);
           const rstats = fs.fstatSync(stats.real);
-          let atim = rstats.atimeMs;
-          let mtim = rstats.mtimeMs;
+          let atim = rstats.atime;
+          let mtim = rstats.mtime;
           const n = nsToMs(now(WASI_CLOCK_REALTIME)!);
           const atimflags = WASI_FILESTAT_SET_ATIM | WASI_FILESTAT_SET_ATIM_NOW;
           if ((fstflags & atimflags) === atimflags) {
@@ -1038,8 +1038,8 @@ export default class WASIDefault {
           }
           this.refreshMemory();
           const rstats = fs.fstatSync(stats.real);
-          let atim = rstats.atimeMs;
-          let mtim = rstats.mtimeMs;
+          let atim = rstats.atime;
+          let mtim = rstats.mtime;
           const n = nsToMs(now(WASI_CLOCK_REALTIME)!);
           const atimflags = WASI_FILESTAT_SET_ATIM | WASI_FILESTAT_SET_ATIM_NOW;
           if ((fstflags & atimflags) === atimflags) {

--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -496,7 +496,7 @@ export default class WASIDefault {
         case WASI_CLOCK_MONOTONIC:
           return bindings.hrtime();
         case WASI_CLOCK_REALTIME:
-          return msToNs(new Date().valueOf());
+          return msToNs(Date.now());
         case WASI_CLOCK_PROCESS_CPUTIME_ID:
         case WASI_CLOCK_THREAD_CPUTIME_ID:
           // return bindings.hrtime(CPUTIME_START)

--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -691,8 +691,8 @@ export default class WASIDefault {
           }
           fs.futimesSync(
             stats.real,
-            atim,
-            mtim
+            new Date(atim),
+            new Date(mtim)
           );
           return WASI_ESUCCESS;
         }
@@ -1067,8 +1067,8 @@ export default class WASIDefault {
           ).toString();
           fs.utimesSync(
             path.resolve(stats.path, p),
-            atim,
-            mtim
+            new Date(atim),
+            new Date(mtim)
           );
           return WASI_ESUCCESS;
         }

--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -1026,11 +1026,12 @@ export default class WASIDefault {
       path_filestat_set_times: wrap(
         (
           fd: number,
-          fstflags: number,
+          dirflags: number,
           pathPtr: number,
           pathLen: number,
           stAtim: number,
-          stMtim: number
+          stMtim: number,
+          fstflags: number
         ) => {
           const stats = CHECK_FD(fd, WASI_RIGHT_PATH_FILESTAT_SET_TIMES);
           if (!stats.path) {


### PR DESCRIPTION
This seemed like the correct behavior, and I verified that this is the behavior that I get when running with Rust/wasmtime. I wanted to check the official wasmer behavior, but I'm not certain how wasmer numbers preopened file descriptors 😅