### PR TITLE
[wasi] fd_pwrite convert offset to number

### DIFF
--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -719,7 +719,7 @@ export default class WASIDefault {
                 iov,
                 w,
                 iov.byteLength - w,
-                offset + written + w
+                Number(offset) + written + w
               );
             }
             written += w;


### PR DESCRIPTION
`fs.writeSync` expects `offset` (BigInt) to be a number.