### PR TITLE
Add lowering to example in README

### DIFF
--- a/packages/wasi/README.md
+++ b/packages/wasi/README.md
@@ -63,8 +63,8 @@ const startWasiTask = async () => {
 
   // Instantiate the WebAssembly file
   const wasm_bytes = new Uint8Array(responseArrayBuffer).buffer;
-  const lowered_wasm = lowerI64Imports(wasm_bytes);
-  let module = await WebAssembly.compile(lowered_wasm.buffer);
+  const lowered_wasm = await lowerI64Imports(wasm_bytes);
+  let module = await WebAssembly.compile(lowered_wasm);
   let instance = await WebAssembly.instantiate(module, {
     ...wasi.getImports(module)
   });

--- a/packages/wasi/README.md
+++ b/packages/wasi/README.md
@@ -39,6 +39,7 @@ npm install --save @wasmer/wasi
 ```js
 import { WASI } from "@wasmer/wasi";
 import wasiBindings from "@wasmer/wasi/lib/bindings/node";
+import { lowerI64Imports } from "@wasmer/wasm-transformer"
 // Use this on the browser
 // import wasiBindings from "@wasmer/wasi/lib/bindings/browser";
 
@@ -62,7 +63,8 @@ const startWasiTask = async () => {
 
   // Instantiate the WebAssembly file
   const wasm_bytes = new Uint8Array(responseArrayBuffer).buffer;
-  let module = await WebAssembly.compile(wasm_bytes);
+  const lowered_wasm = lowerI64Imports(wasm_bytes);
+  let module = await WebAssembly.compile(lowered_wasm.buffer);
   let instance = await WebAssembly.instantiate(module, {
     ...wasi.getImports(module)
   });


### PR DESCRIPTION
I think it would be helpful for users to see that lowering (in most cases) is required in the README. I know it tripped me up for a few hours.