### PR TITLE
Convert BigInt to Number in the DataView polyfill

### DIFF
--- a/packages/wasi/src/polyfills/dataview.ts
+++ b/packages/wasi/src/polyfills/dataview.ts
@@ -16,7 +16,7 @@ if (!exportedDataView.prototype.setBigUint64) {
     let highWord;
 
     if (value < 2 ** 32) {
-      lowWord = value;
+      lowWord = Number(value);
       highWord = 0;
     } else {
       var bigNumberAsBinaryStr = value.toString(2);


### PR DESCRIPTION
Without this conversion the function throws the `Conversion from 'BigInt' to 'number' is not allowed` error on Safari 14, which has the `BigInt` type, but doesn't have `setBigUint64` available on `DataView`.