### PR TITLE
A flag to enable syscall trace for debugging purposes.

### DIFF
--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -335,6 +335,7 @@ export type WASIConfig = {
   env?: WASIEnv;
   args?: WASIArgs;
   bindings?: WASIBindings;
+  traceSyscalls?: boolean;
 };
 
 export class WASIError extends Error {
@@ -1480,20 +1481,22 @@ export default class WASIDefault {
       }
     };
     // Wrap each of the imports to show the calls in the console
-    // Object.keys(this.wasiImport).forEach((key: string) => {
-    //   const prevImport = this.wasiImport[key];
-    //   this.wasiImport[key] = function(...args: any[]) {
-    //     console.log(`WASI: wasiImport called: ${key} (${args})`);
-    //     try {
-    //       let result = prevImport(...args);
-    //       console.log(`WASI:  => ${result}`);
-    //       return result;
-    //     } catch (e) {
-    //       console.log(`Catched error: ${e}`);
-    //       throw e;
-    //     }
-    //   };
-    // });
+    if ((wasiConfig as WASIConfig).traceSyscalls) {
+      Object.keys(this.wasiImport).forEach((key: string) => {
+        const prevImport = this.wasiImport[key];
+        this.wasiImport[key] = function(...args: any[]) {
+          console.log(`WASI: wasiImport called: ${key} (${args})`);
+          try {
+            let result = prevImport(...args);
+            console.log(`WASI:  => ${result}`);
+            return result;
+          } catch (e) {
+            console.log(`Catched error: ${e}`);
+            throw e;
+          }
+        };
+      });
+    }
   }
 
   refreshMemory() {


### PR DESCRIPTION
I found the commented-out code segment at the end of the `WASIDefault` constructor most valuable when debugging syscall-related problems. After I found myself un-commenting and re-commenting it, I thought to suggest to you that this could be a config option.

I named the field `traceSyscalls`. Alternatively, you could have a field called `trace` which is an object with flags for different kinds of traces, but atm it felt like an overkill.