### PR TITLE
Catch throwable stat call to memfs

### DIFF
--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -1224,10 +1224,16 @@ export default class WASIDefault {
               throw e;
             }
           }
-          let realfd
+
           /* check if the file is a directory (unless opening for write,
            * in which case the file may not exist and should be created) */
-          if (!write && fs.statSync(full).isDirectory()) {
+          let isDirectory;
+          try {
+            isDirectory = fs.statSync(full).isDirectory()
+          } catch (e) {}
+
+          let realfd;
+          if (!write && isDirectory) {
             realfd = fs.openSync(full, fs.constants.O_RDONLY)
           } else {
             realfd = fs.openSync(full, noflags);


### PR DESCRIPTION
fs.statSync will throw an error if a file doesn't exist. This is problematic when opening a file with O_CREAT flag, in which case the call fails silently.