### PR TITLE
Fix build error in wasm_transformer_cli

### DIFF
--- a/examples/wasm_transformer_cli/src/main.rs
+++ b/examples/wasm_transformer_cli/src/main.rs
@@ -1,5 +1,4 @@
 use std::*;
-use wasm_transformer::*;
 use clap::{Arg, App};
 
 const NAME: &str = env!("CARGO_PKG_NAME");
@@ -24,7 +23,7 @@ fn main() {
     println!(" ");
 
     // Run the transformation on the file
-    let mut Wasm = fs::read(wasm_file_path).unwrap();
+    let wasm = fs::read(wasm_file_path).unwrap();
     let lowered_wasm = wasm_transformer::lower_i64_imports(wasm);
     fs::write("./out.wasm", &lowered_wasm).expect("Unable to write file");
 


### PR DESCRIPTION
```error[E0425]: cannot find value `wasm` in this scope``` + a couple of warnings