### PR TITLE
fix(cli): The displayed version number is now correct

### DIFF
--- a/packages/cli/src/package.json
+++ b/packages/cli/src/package.json
@@ -1,1 +1,0 @@
-package.json

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -2,5 +2,5 @@
 import pkginfo from 'pkginfo';
 
 export const getVersion = () => {
-    return pkginfo(module, 'version').version;
+    return pkginfo.find(module).version;
 }


### PR DESCRIPTION
`wasmer-js` displays the wrong version number. This patch fixes this issues.

## Actual behavior

```bash
npm install -g @wasmer/cli
wasmer-js -V
wasmer-js 0.4.1
```

But

```bash
grep version /usr/local/lib/node_modules/@wasmer/cli/package.json
"version": "0.12.0"
```

## Expected

```bash
npm install -g @wasmer/cli
wasmer-js -V
wasmer-js 0.12.0
```