### PR TITLE
Use WASI.defaultBindings in examples for @wasmer/wasi

### DIFF
--- a/packages/wasi/README.md
+++ b/packages/wasi/README.md
@@ -38,10 +38,7 @@ npm install --save @wasmer/wasi
 
 ```js
 import { WASI } from "@wasmer/wasi";
-import wasiBindings from "@wasmer/wasi/lib/bindings/node";
 import { lowerI64Imports } from "@wasmer/wasm-transformer"
-// Use this on the browser
-// import wasiBindings from "@wasmer/wasi/lib/bindings/browser";
 
 import { WasmFs } from "@wasmer/wasmfs";
 
@@ -51,7 +48,8 @@ let wasi = new WASI({
   args: [],
   env: {},
   bindings: {
-    ...wasiBindings,
+    // uses browser APIs in the browser, node APIs in node
+    ...WASI.defaultBindings,
     fs: wasmFs.fs
   }
 });


### PR DESCRIPTION
This tripped me up when trying to upgrade, since the `/*ROLLUP_REPLACE_NODE` directive didn't get removed when directly importing from `lib/bindings/browser`