### PR TITLE
fix: cannot create WASI() object with no options & default bindings not working as expected

### DIFF
--- a/packages/wasi/src/index.ts
+++ b/packages/wasi/src/index.ts
@@ -391,7 +391,7 @@ export default class WASIDefault {
     if (wasiConfig && wasiConfig.args) {
       args = wasiConfig.args;
     }
-    let bindings: WASIBindings = defaultBindings;
+    let bindings: WASIBindings = WASIDefault.defaultBindings;
     if (wasiConfig && wasiConfig.bindings) {
       bindings = wasiConfig.bindings;
     }
@@ -1487,7 +1487,7 @@ export default class WASIDefault {
       }
     };
     // Wrap each of the imports to show the calls in the console
-    if ((wasiConfig as WASIConfig).traceSyscalls) {
+    if (wasiConfig && (wasiConfig as WASIConfig).traceSyscalls) {
       Object.keys(this.wasiImport).forEach((key: string) => {
         const prevImport = this.wasiImport[key];
         this.wasiImport[key] = function(...args: any[]) {

--- a/packages/wasi/test/wasi.test.ts
+++ b/packages/wasi/test/wasi.test.ts
@@ -16,6 +16,7 @@ if ((global as any).BigInt) {
 }
 import { WASI } from "../src";
 import WASINodeBindings from "../src/bindings/node";
+WASI.defaultBindings = WASINodeBindings
 
 const bytesConverter = (buffer: Buffer): Buffer => {
   // Help debugging: https://webassembly.github.io/wabt/demo/wat2wasm/index.html
@@ -105,19 +106,8 @@ describe("WASI interaction", () => {
   });
 
   it("Can instantiate with undefined paramaters, or empty object", () => {
-    try {
-      let wasi = new WASI();
-    } catch (e) {
-      // Ensure the error is about the node bindings, not empty initialization
-      expect(e.message.includes("'fs'")).toBe(true);
-    }
-
-    try {
-      let wasi = new WASI({});
-    } catch (e) {
-      // Ensure the error is about the node bindings, not empty initialization
-      expect(e.message.includes("'fs'")).toBe(true);
-    }
+    new WASI();
+    new WASI({});
   });
 
   it("Helloworld can be run", async () => {


### PR DESCRIPTION
The error was being hid by the lack of bindings on the WASI object during tests. It appears we use a build time process to include the right bindings and assign it to a static property on the object. We don't actually use the static property however when constructing the WASI object. This patch fixes that as well. And if that's fixed there doesn't seem to be a reason not to use node bindings in the tests which no longer hides the error of not being able to construct without options.