### PR TITLE
Allow setting `fs` in WASI config

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -67,7 +67,7 @@ impl MemFS {
     }
 
     pub fn from_js(jso: JsValue) -> Result<MemFS, JsValue> {
-        generic_of_jsval(jso, "MemFS")
+        Ok(generic_of_jsval::<MemFS>(jso, "MemFS")?.clone())
     }
 
     #[wasm_bindgen(js_name = readDir)]

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,6 +7,7 @@ use wasmer_vfs::mem_fs::FileSystem as MemoryFilesystem;
 use wasmer_vfs::{
     DirEntry, FileSystem, FileType, FsError, Metadata, OpenOptions, ReadDir, VirtualFile,
 };
+use crate::wasi::generic_of_jsval;
 
 #[wasm_bindgen]
 #[derive(Debug, Clone)]
@@ -63,6 +64,10 @@ impl MemFS {
         Ok(MemFS {
             inner: Arc::new(MemoryFilesystem::default()),
         })
+    }
+
+    pub fn from_js(jso: JsValue) -> Result<MemFS, JsValue> {
+        generic_of_jsval(jso, "MemFS")
     }
 
     #[wasm_bindgen(js_name = readDir)]

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -220,7 +220,7 @@ impl WASI {
             self.instantiate(instance.into(), None)?;
         } else if self.instance.is_none() {
             return Err(
-                js_sys::Error::new("You need to provide a instance as argument to start, or call `wasi.instantiate` with the `WebAssembly.Instance` manually").into(),
+                js_sys::Error::new("You need to provide an instance as argument to `start`, or call `wasi.instantiate` with the `WebAssembly.Instance` manually").into(),
             );
         }
         let start = self

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -6,6 +6,8 @@ use wasmer::{Imports, Instance, Module, Store};
 use wasmer_wasi::Pipe;
 use wasmer_wasi::{Stderr, Stdin, Stdout, WasiError, WasiFunctionEnv, WasiState};
 
+use wasm_bindgen::convert::FromWasmAbi;
+
 #[wasm_bindgen]
 pub struct WASI {
     store: Store,
@@ -86,9 +88,7 @@ impl WASI {
             if fs.is_undefined() {
                 MemFS::new()?
             } else {
-                MemFS::new()?
-                // let mem_fs: MemFS = fs.dyn_into()?;
-                // mem_fs
+                MemFS::from_js(fs)?
             }
         };
         let mut store = Store::default();
@@ -324,5 +324,20 @@ impl WASI {
     #[wasm_bindgen(js_name = setStdinString)]
     pub fn set_stdin_string(&mut self, input: String) -> Result<(), JsValue> {
         self.set_stdin_buffer(input.as_bytes())
+    }
+}
+
+// helper function for passing Rust objects through JS
+// https://github.com/rustwasm/wasm-bindgen/issues/2231#issuecomment-656293288
+pub fn generic_of_jsval<T: FromWasmAbi<Abi=u32>>(js: JsValue, classname: &str) -> Result<T, JsValue> {
+    use js_sys::{Object, Reflect};
+    let ctor_name = Object::get_prototype_of(&js).constructor().name();
+    if ctor_name == classname {
+        let ptr = Reflect::get(&js, &JsValue::from_str("ptr"))?;
+        let ptr_u32: u32 = ptr.as_f64().ok_or(JsValue::NULL)? as u32;
+        let foo = unsafe { T::from_abi(ptr_u32) };
+        Ok(foo)
+    } else {
+        Err(JsValue::NULL)
     }
 }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -332,9 +332,9 @@ impl WASI {
 // https://github.com/rustwasm/wasm-bindgen/issues/2231#issuecomment-1147260391
 pub fn generic_of_jsval<T: RefFromWasmAbi<Abi=u32>>(js: JsValue, classname: &str) -> Result<T::Anchor, JsValue> {
     if !js.is_object() {
-        return Err(JsValue::from_str(
-            format!("Value supplied as {} is not an object", classname).as_str(),
-        ));
+        return Err(js_sys::Error::new(
+            &format!("expected object, got {:?}", js).as_str(),
+        ).into());
     }
 
     let ctor_name = Object::get_prototype_of(&js).constructor().name();
@@ -344,6 +344,8 @@ pub fn generic_of_jsval<T: RefFromWasmAbi<Abi=u32>>(js: JsValue, classname: &str
         let foo = unsafe { T::ref_from_abi(ptr_u32) };
         Ok(foo)
     } else {
-        Err(JsValue::NULL)
+        Err(js_sys::Error::new(
+          &format!("expected '{}', got '{}'", classname, ctor_name).as_str()
+        ).into())
     }
 }


### PR DESCRIPTION
I noticed the use case where `fs` is passed in config is unhandled, and I assume it was because wasm-bound `MemFS` does not implement `JsCast`, making it hard to pass it to JS and then get it back in the WASI ctor.

I have adopted some [common wisdom](https://github.com/rustwasm/wasm-bindgen/issues/2231#issuecomment-656293288) that I've found on github to get the wrapped instance from a JS object and pass it along. Are you interested?