### PR TITLE
Clean up deno example

### DIFF
--- a/examples/deno/README.md
+++ b/examples/deno/README.md
@@ -5,7 +5,7 @@
 This example outputs hello world in the `stdout`.
 
 ```
-$ deno run --allow-read --allow-net helloworld.ts
+$ deno run --allow-net helloworld.ts
 hello world
 (exit code: 0)
 ```
@@ -15,7 +15,7 @@ hello world
 This example lists the files and directories on `/`.
 
 ```
-$ deno run --allow-read --allow-net fs.ts
+$ deno run --allow-net fs.ts
 "./a"
 "./b"
 "./file"

--- a/examples/deno/fs.ts
+++ b/examples/deno/fs.ts
@@ -1,25 +1,27 @@
-import { init, WASI } from 'https://deno.land/x/wasm/wasi.ts';
+import { init, WASI } from "https://deno.land/x/wasm/wasi.ts";
 
 // This is needed to load the WASI library first
 await init();
 
-let wasi = new WASI({
+const wasi = new WASI({
   env: {},
   args: [],
 });
 
-const moduleBytes = fetch("https://cdn.deno.land/wasm/versions/v1.0.1/raw/tests/mapdir.wasm");
+const moduleBytes = fetch(
+  "https://cdn.deno.land/wasm/versions/v1.0.2/raw/tests/mapdir.wasm",
+);
 const module = await WebAssembly.compileStreaming(moduleBytes);
 await wasi.instantiate(module, {});
 
 wasi.fs.createDir("/a");
 wasi.fs.createDir("/b");
 
-let file = wasi.fs.open("/file", {read: true, write: true, create: true});
+const file = wasi.fs.open("/file", { read: true, write: true, create: true });
 file.writeString("fileContents");
 file.seek(0);
 
-let exitCode = wasi.start();
-let stdout = wasi.getStdoutString();
+const exitCode = wasi.start();
+const stdout = wasi.getStdoutString();
 // This should print "hello world (exit code: 0)"
 console.log(`${stdout}(exit code: ${exitCode})`);

--- a/examples/deno/helloworld.ts
+++ b/examples/deno/helloworld.ts
@@ -1,18 +1,20 @@
-import { init, WASI } from 'https://deno.land/x/wasm/wasi.ts';
+import { init, WASI } from "https://deno.land/x/wasm/wasi.ts";
 
 // This is needed to load the WASI library first
 await init();
 
-let wasi = new WASI({
+const wasi = new WASI({
   env: {},
   args: [],
 });
 
-const moduleBytes = fetch("https://cdn.deno.land/wasm/versions/v1.0.1/raw/tests/demo.wasm");
+const moduleBytes = fetch(
+  "https://cdn.deno.land/wasm/versions/v1.0.2/raw/tests/demo.wasm",
+);
 const module = await WebAssembly.compileStreaming(moduleBytes);
 await wasi.instantiate(module, {});
 
-let exitCode = wasi.start();
-let stdout = wasi.getStdoutString();
- // This should print "hello world (exit code: 0)"
+const exitCode = wasi.start();
+const stdout = wasi.getStdoutString();
+// This should print "hello world (exit code: 0)"
 console.log(`${stdout}(exit code: ${exitCode})`);


### PR DESCRIPTION
This PR:
- Remove unneeded permission from the README
- deno fmt
- fix warnings

Couple of questions:

- Does this need better typing ? or the await is actually not needed
![image](https://user-images.githubusercontent.com/22427111/205086449-cd28c124-bed6-4f31-99e8-ddff3a559934.png)

- Is there a simple example where there is actual system read, just to showcase `deno --allow-read` working in synergy with the wasm permissions