### PR TITLE
Cleanup + modernize examples

### DIFF
--- a/examples/deno/fs.ts
+++ b/examples/deno/fs.ts
@@ -12,7 +12,7 @@ const moduleBytes = fetch(
   "https://cdn.deno.land/wasm/versions/v1.0.2/raw/tests/mapdir.wasm",
 );
 const module = await WebAssembly.compileStreaming(moduleBytes);
-await wasi.instantiate(module, {});
+wasi.instantiate(module, {});
 
 wasi.fs.createDir("/a");
 wasi.fs.createDir("/b");

--- a/examples/deno/helloworld.ts
+++ b/examples/deno/helloworld.ts
@@ -12,7 +12,7 @@ const moduleBytes = fetch(
   "https://cdn.deno.land/wasm/versions/v1.0.2/raw/tests/demo.wasm",
 );
 const module = await WebAssembly.compileStreaming(moduleBytes);
-await wasi.instantiate(module, {});
+wasi.instantiate(module, {});
 
 const exitCode = wasi.start();
 const stdout = wasi.getStdoutString();

--- a/examples/node/fs.mjs
+++ b/examples/node/fs.mjs
@@ -14,7 +14,7 @@ const buf = fs.readFileSync('../../tests/mapdir.wasm');
 const module = await WebAssembly.compile(
   new Uint8Array(buf)
 );
-await wasi.instantiate(module, {});
+wasi.instantiate(module, {});
 
 wasi.fs.createDir("/a");
 wasi.fs.createDir("/b");

--- a/examples/node/fs.mjs
+++ b/examples/node/fs.mjs
@@ -11,9 +11,7 @@ let wasi = new WASI({
 
 const buf = fs.readFileSync('../../tests/mapdir.wasm');
 
-const module = await WebAssembly.compile(
-  new Uint8Array(buf)
-);
+const module = await WebAssembly.compile(buf);
 wasi.instantiate(module, {});
 
 wasi.fs.createDir("/a");

--- a/examples/node/fs.mjs
+++ b/examples/node/fs.mjs
@@ -4,12 +4,12 @@ import { init, WASI } from "@wasmer/wasi";
 // This is needed to load the WASI library first
 await init();
 
-let wasi = new WASI({
+const wasi = new WASI({
   env: {},
   args: [],
 });
 
-const buf = await readFile('../../tests/mapdir.wasm');
+const buf = await readFile("../../tests/mapdir.wasm");
 
 const module = await WebAssembly.compile(buf);
 wasi.instantiate(module, {});
@@ -17,12 +17,12 @@ wasi.instantiate(module, {});
 wasi.fs.createDir("/a");
 wasi.fs.createDir("/b");
 
-let file = wasi.fs.open("/file", {read: true, write: true, create: true});
+const file = wasi.fs.open("/file", { read: true, write: true, create: true });
 file.writeString("fileContents");
 file.seek(0);
 
-let exitCode = wasi.start();
-let stdout = wasi.getStdoutString();
+const exitCode = wasi.start();
+const stdout = wasi.getStdoutString();
 
 // This should print "hello world (exit code: 0)"
 console.log(`${stdout}(exit code: ${exitCode})`);

--- a/examples/node/fs.mjs
+++ b/examples/node/fs.mjs
@@ -1,4 +1,4 @@
-import fs from "fs";
+import { readFile } from "node:fs/promises";
 import { init, WASI } from "@wasmer/wasi";
 
 // This is needed to load the WASI library first
@@ -9,7 +9,7 @@ let wasi = new WASI({
   args: [],
 });
 
-const buf = fs.readFileSync('../../tests/mapdir.wasm');
+const buf = await readFile('../../tests/mapdir.wasm');
 
 const module = await WebAssembly.compile(buf);
 wasi.instantiate(module, {});

--- a/examples/node/helloworld.mjs
+++ b/examples/node/helloworld.mjs
@@ -1,4 +1,4 @@
-import fs from "fs";
+import { readFile } from "node:fs/promises";
 import { init, WASI } from "@wasmer/wasi";
 
 // This is needed to load the WASI library first
@@ -9,7 +9,7 @@ let wasi = new WASI({
   args: [],
 });
 
-const buf = fs.readFileSync('../../tests/demo.wasm');
+const buf = await readFile('../../tests/demo.wasm');
 
 const module = await WebAssembly.compile(buf);
 wasi.instantiate(module, {});

--- a/examples/node/helloworld.mjs
+++ b/examples/node/helloworld.mjs
@@ -14,7 +14,7 @@ const buf = fs.readFileSync('../../tests/demo.wasm');
 const module = await WebAssembly.compile(
   new Uint8Array(buf)
 );
-await wasi.instantiate(module, {});
+wasi.instantiate(module, {});
 
 let exitCode = wasi.start();
 let stdout = wasi.getStdoutString();

--- a/examples/node/helloworld.mjs
+++ b/examples/node/helloworld.mjs
@@ -4,17 +4,17 @@ import { init, WASI } from "@wasmer/wasi";
 // This is needed to load the WASI library first
 await init();
 
-let wasi = new WASI({
+const wasi = new WASI({
   env: {},
   args: [],
 });
 
-const buf = await readFile('../../tests/demo.wasm');
+const buf = await readFile("../../tests/demo.wasm");
 
 const module = await WebAssembly.compile(buf);
 wasi.instantiate(module, {});
 
-let exitCode = wasi.start();
-let stdout = wasi.getStdoutString();
+const exitCode = wasi.start();
+const stdout = wasi.getStdoutString();
 // This should print "hello world (exit code: 0)"
 console.log(`${stdout}(exit code: ${exitCode})`);

--- a/examples/node/helloworld.mjs
+++ b/examples/node/helloworld.mjs
@@ -11,9 +11,7 @@ let wasi = new WASI({
 
 const buf = fs.readFileSync('../../tests/demo.wasm');
 
-const module = await WebAssembly.compile(
-  new Uint8Array(buf)
-);
+const module = await WebAssembly.compile(buf);
 wasi.instantiate(module, {});
 
 let exitCode = wasi.start();


### PR DESCRIPTION
remove `await` when calling `wasi.instantiate` (which does not return a Promise).

use `node:` protocol, use async `fs/promises`, consistent const (compare to deno examples)