### PR TITLE
Remove the global `Buffer` dependency

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -2,7 +2,7 @@ export * from "./pkg/wasmer_wasi_js";
 import load from "./pkg/wasmer_wasi_js";
 import wasm_bytes from "./pkg/wasmer_wasi_js_bg.wasm";
 
-interface MimeBuffer extends Buffer {
+interface MimeBuffer extends ArrayBuffer {
 	type: string;
 	typeFull: string;
 	charset: string;
@@ -55,9 +55,8 @@ function dataUriToBuffer(uri: string): MimeBuffer {
 	}
 
 	// get the encoded data portion and decode URI-encoded chars
-	const encoding = base64 ? 'base64' : 'ascii';
 	const data = unescape(uri.substring(firstComma + 1));
-	const buffer = Buffer.from(data, encoding) as MimeBuffer;
+	const buffer = Uint8Array.from(base64 ? atob(data) : data, c => c.charCodeAt(0)).buffer as MimeBuffer;
 
 	// set `.type` and `.typeFull` properties to MIME type
 	buffer.type = type;


### PR DESCRIPTION
The global `Buffer` is used for loading base64 encoded string. However, this *implicit* and *global* dependency make some confusion and problems (#294, #305, and ruby/ruby.wasm#182).

The use of `Buffer` here is limited, so we can easily replace this by using `atob` function. This simplifies the user's build settings and reduces the file size since there is no need to include Buffer.

Thank you.