### PR TITLE
Use a global `Runtime` when one isn't explicitly provided

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4373,9 +4373,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"

--- a/src/container.rs
+++ b/src/container.rs
@@ -7,7 +7,7 @@ use shared_buffer::OwnedBuffer;
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast};
 use wasmer_wasix::{runtime::resolver::PackageSpecifier, Runtime as _};
 
-use crate::{utils::Error, Runtime};
+use crate::{utils::Error, JsRuntime};
 
 #[wasm_bindgen]
 pub struct Container {
@@ -28,7 +28,7 @@ impl Container {
     /// Download a package from the registry.
     pub async fn from_registry(
         package_specifier: &str,
-        runtime: &Runtime,
+        runtime: &JsRuntime,
     ) -> Result<Container, Error> {
         let source = runtime.source();
         let package_specifier: PackageSpecifier = package_specifier

--- a/src/js_runtime.rs
+++ b/src/js_runtime.rs
@@ -118,13 +118,13 @@ extern "C" {
     #[wasm_bindgen(typescript_type = "RuntimeOptions")]
     pub type RuntimeOptions;
 
-    #[wasm_bindgen(method, js_name = "poolSize")]
+    #[wasm_bindgen(method, getter, js_name = "poolSize")]
     fn pool_size(this: &RuntimeOptions) -> Option<usize>;
 
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, getter)]
     fn registry(this: &RuntimeOptions) -> Option<MaybeRegistryUrl>;
 
-    #[wasm_bindgen(method, js_name = "apiKey")]
+    #[wasm_bindgen(method, getter, js_name = "apiKey")]
     fn api_key(this: &RuntimeOptions) -> Option<String>;
 
     #[wasm_bindgen(typescript_type = "string | null | undefined")]

--- a/src/js_runtime.rs
+++ b/src/js_runtime.rs
@@ -1,0 +1,146 @@
+use std::{
+    num::NonZeroUsize,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+use wasm_bindgen::{prelude::wasm_bindgen, JsCast};
+
+use crate::{runtime::Runtime, tasks::ThreadPool, utils::Error};
+
+#[derive(Clone, Debug, wasm_bindgen_derive::TryFromJsValue)]
+#[wasm_bindgen(js_name = "Runtime")]
+pub struct JsRuntime {
+    // Note: This is just a wrapper around the "real" runtime implementation.
+    // We need it because most JS-facing methods will want to accept/return an
+    // `Arc<Runtime>`, but wasm-bindgen doesn't support passing Arc around
+    // directly.
+    rt: Arc<Runtime>,
+}
+
+#[wasm_bindgen(js_class = "Runtime")]
+impl JsRuntime {
+    #[wasm_bindgen(constructor)]
+    pub fn new(options: Option<RuntimeOptions>) -> Result<JsRuntime, Error> {
+        let pool_size = options.as_ref().and_then(|options| options.pool_size());
+
+        let pool = match pool_size {
+            Some(size) => {
+                let size = NonZeroUsize::new(size).unwrap_or(NonZeroUsize::MIN);
+                ThreadPool::new(size)
+            }
+            None => ThreadPool::new_with_max_threads()?,
+        };
+
+        let registry = match options.as_ref().and_then(|opts| opts.registry()) {
+            Some(registry_url) => registry_url.resolve(),
+            None => Some(crate::DEFAULT_REGISTRY.to_string()),
+        };
+
+        let mut rt = Runtime::new(pool);
+
+        if let Some(registry) = registry.as_deref() {
+            let api_key = options.as_ref().and_then(|opts| opts.api_key());
+            rt.set_registry(registry, api_key.as_deref())?;
+        }
+
+        Ok(JsRuntime { rt: Arc::new(rt) })
+    }
+
+    /// Get a reference to the global runtime, optionally initializing it if
+    /// requested.
+    pub fn global(initialize: Option<bool>) -> Result<Option<JsRuntime>, Error> {
+        match Runtime::global() {
+            Some(rt) => Ok(Some(JsRuntime { rt })),
+            None if initialize == Some(true) => {
+                let rt = Runtime::lazily_initialized()?;
+                Ok(Some(JsRuntime { rt }))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+impl Deref for JsRuntime {
+    type Target = Arc<Runtime>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.rt
+    }
+}
+
+impl DerefMut for JsRuntime {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.rt
+    }
+}
+
+impl From<Arc<Runtime>> for JsRuntime {
+    fn from(value: Arc<Runtime>) -> Self {
+        JsRuntime { rt: value }
+    }
+}
+
+impl AsRef<Arc<Runtime>> for JsRuntime {
+    fn as_ref(&self) -> &Arc<Runtime> {
+        self
+    }
+}
+
+#[wasm_bindgen(typescript_custom_section)]
+const RUNTIME_OPTIONS_TYPE_DECLARATION: &str = r#"
+/**
+ * Options used when constructing a {@link Runtime}.
+ */
+export type RuntimeOptions = {
+    /**
+     * The number of worker threads to use.
+     */
+    poolSize?: number;
+    /**
+     * The GraphQL endpoint for the Wasmer registry used when looking up
+     * packages.
+     *
+     * Defaults to `"https://registry.wasmer.io/graphql"`.
+     *
+     * If `null`, no queries will be made to the registry.
+     */
+    registry?: string | null;
+    /**
+     * An optional API key to use when sending requests to the Wasmer registry.
+     */
+    apiKey?: string;
+};
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "RuntimeOptions")]
+    pub type RuntimeOptions;
+
+    #[wasm_bindgen(method, js_name = "poolSize")]
+    fn pool_size(this: &RuntimeOptions) -> Option<usize>;
+
+    #[wasm_bindgen(method)]
+    fn registry(this: &RuntimeOptions) -> Option<MaybeRegistryUrl>;
+
+    #[wasm_bindgen(method, js_name = "apiKey")]
+    fn api_key(this: &RuntimeOptions) -> Option<String>;
+
+    #[wasm_bindgen(typescript_type = "string | null | undefined")]
+    type MaybeRegistryUrl;
+}
+
+impl MaybeRegistryUrl {
+    fn resolve(&self) -> Option<String> {
+        if self.is_undefined() {
+            Some(crate::DEFAULT_REGISTRY.to_string())
+        } else if self.is_null() {
+            None
+        } else if let Some(s) = self.dyn_ref::<js_sys::JsString>() {
+            Some(s.into())
+        } else {
+            unreachable!()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod container;
 mod facade;
 pub mod fs;
 mod instance;
+mod js_runtime;
 mod logging;
 mod net;
 mod options;
@@ -20,15 +21,16 @@ mod ws;
 
 use std::sync::Mutex;
 
+pub(crate) use crate::runtime::Runtime;
 pub use crate::{
     container::{Container, Manifest, Volume},
     facade::{Wasmer, WasmerConfig},
     fs::{Directory, DirectoryInit},
     instance::{Instance, JsOutput},
+    js_runtime::{JsRuntime, RuntimeOptions},
     logging::initialize_logger,
     options::{RunOptions, SpawnOptions},
     run::run,
-    runtime::Runtime,
     utils::StringOrBytes,
 };
 
@@ -38,6 +40,8 @@ use wasm_bindgen::prelude::wasm_bindgen;
 pub(crate) const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 pub(crate) const DEFAULT_RUST_LOG: &[&str] = &["warn"];
 pub(crate) static CUSTOM_WORKER_URL: Lazy<Mutex<Option<String>>> = Lazy::new(Mutex::default);
+pub(crate) const DEFAULT_REGISTRY: &str =
+    wasmer_wasix::runtime::resolver::WapmSource::WASMER_PROD_ENDPOINT;
 
 #[wasm_bindgen]
 pub fn wat2wasm(wat: String) -> Result<js_sys::Uint8Array, utils::Error> {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -105,12 +105,7 @@ impl Write for ConsoleLogger {
 impl Drop for ConsoleLogger {
     fn drop(&mut self) {
         if !self.buffer.is_empty() {
-            if let Err(e) = self.flush() {
-                tracing::warn!(
-                    error = &e as &dyn std::error::Error,
-                    "An error occurred while flushing",
-                );
-            }
+            let _ = self.flush();
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -6,7 +6,7 @@ use virtual_fs::TmpFileSystem;
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue, UnwrapThrowExt};
 use wasmer_wasix::WasiEnvBuilder;
 
-use crate::{utils::Error, Directory, DirectoryInit, Runtime, StringOrBytes};
+use crate::{utils::Error, Directory, DirectoryInit, JsRuntime, StringOrBytes};
 
 #[wasm_bindgen]
 extern "C" {
@@ -229,13 +229,13 @@ impl RunOptions {
 }
 
 impl OptionalRuntime {
-    pub(crate) fn as_runtime(&self) -> Option<Runtime> {
+    pub(crate) fn as_runtime(&self) -> Option<JsRuntime> {
         let js_value: &JsValue = self.as_ref();
 
         if js_value.is_undefined() {
             None
         } else {
-            let rt = Runtime::try_from(js_value).expect_throw("Expected a runtime");
+            let rt = JsRuntime::try_from(js_value).expect_throw("Expected a runtime");
             Some(rt)
         }
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -14,8 +14,8 @@ pub async fn run(wasm_module: WasmModule, config: RunOptions) -> Result<Instance
     let _span = tracing::debug_span!("run").entered();
 
     let runtime = match config.runtime().as_runtime() {
-        Some(rt) => Arc::new(rt.clone()),
-        None => Arc::new(Runtime::with_pool_size(None)?),
+        Some(rt) => Arc::clone(&*rt),
+        None => Runtime::lazily_initialized()?,
     };
 
     let program_name = config

--- a/src/run.rs
+++ b/src/run.rs
@@ -38,7 +38,6 @@ pub async fn run(wasm_module: WasmModule, config: RunOptions) -> Result<Instance
         Box::new(move |module| {
             let _span = tracing::debug_span!("run").entered();
             let result = builder.run(module).map_err(anyhow::Error::new);
-            tracing::warn!(?result);
             let _ = exit_code_tx.send(ExitCondition::from_result(result));
         }),
     )?;

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -24,7 +24,7 @@ describe("run", function() {
             )`;
         const wasm = wat2wasm(noop);
         const module = await WebAssembly.compile(wasm);
-        const runtime = new Runtime(2);
+        const runtime = new Runtime({ poolSize: 2 });
 
         const instance = await run(module, { program: "noop", runtime });
         const output = await instance.wait();


### PR DESCRIPTION
I've modified things so that functions which require a `Runtime` will use a global instance (or lazily initialize it) when one isn't passed in as an argument.

To make sure we don't consume web workers after users are done with the global `Runtime` instance, we use a `Weak<Runtime>` reference instead of an `Arc<Runtime>`. The `Drop` implementation for our `wasmer_js::tasks::ThreadPool` will automatically kill all worker threads, so that should mean things are cleaned up nicely[^1].

[^1]: plus or minus some lag because Rust objectsin JS-land (like `Runtime` ) are managed by the GC.