### PR TITLE
This makes the url a bit simpler to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ script into a module.
 
 ```html
 <script defer type="module">
-    import { init, Wasmer } from "https://unpkg.com/@wasmer/sdk@latest/dist/Library.mjs";
+    import { init, Wasmer } from "https://unpkg.com/@wasmer/sdk@latest?module";
 
     async function runPython() {
         await init();

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Wasmer JavaScript SDK</title>
     <script defer type="module">
-        import { init, Wasmer } from "https://unpkg.com/@wasmer/sdk@latest/dist/Library.mjs";
+        import { init, Wasmer } from "https://unpkg.com/@wasmer/sdk@latest?module";
 
         async function runPython() {
             const status = document.getElementById("status");


### PR DESCRIPTION
This makes the url a bit simpler to use and less error prone (for example, it will still work once we release the new version that is no longer named `Library.mjs` but `WasmerSDK.mjs`