### PR TITLE
Improve stdout/stderr output

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ const instance = await pkg.entrypoint.run({
     args: ["-c", "print('Hello, World!')"],
 });
 
-const { code, stdoutUtf8 } = await instance.wait();
-console.log(`Python exited with ${code}: ${stdoutUtf8}`);
+const { code, stdout } = await instance.wait();
+console.log(`Python exited with ${code}: ${stdout}`);
 ```
 
 ### Install from CDN
@@ -74,9 +74,9 @@ will be available as the `WasmerSDK` global variable.
               args: ["-c", "print('Hello, World!')"],
           });
 
-          const { code, stdoutUtf8 } = await instance.wait();
+          const { code, stdout } = await instance.wait();
 
-          console.log(`Python exited with ${code}: ${stdoutUtf8}`);
+          console.log(`Python exited with ${code}: ${stdout}`);
       }
 
       runPython();

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -24,11 +24,11 @@
             });
 
             status.innerHTML = `Running ${packageName}...`;
-            const { code, stdoutUtf8 } = await instance.wait();
+            const { code, stdout } = await instance.wait();
 
             status.innerHTML = `Exited with status code: ${code}`;
-            const stdout = document.getElementById("stdout");
-            stdout.innerHTML = stdoutUtf8;
+            const stdoutElement = document.getElementById("stdout");
+            stdoutElement.innerHTML = stdout;
         }
 
         runPython();

--- a/examples/markdown-editor-improved/index.ts
+++ b/examples/markdown-editor-improved/index.ts
@@ -22,7 +22,7 @@ async function renderMarkdown(cmd: Command, markdown: string) {
     await stdin.close();
 
     const result = await instance.wait();
-    return result.ok ? result.stdoutUtf8 : null;
+    return result.ok ? result.stdout : null;
 }
 
 async function main() {

--- a/examples/markdown-editor/index.ts
+++ b/examples/markdown-editor/index.ts
@@ -25,7 +25,7 @@ async function renderMarkdown(module: WebAssembly.Module, markdown: string) {
     await stdin.close();
 
     const result = await instance.wait();
-    return result.ok ? result.stdoutUtf8 : null;
+    return result.ok ? result.stdout : null;
 }
 
 async function main() {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -149,22 +149,22 @@ impl From<Output> for JsOutput {
         let _ = js_sys::Reflect::set(&output, &JsValue::from_str("ok"), &JsValue::from(ok));
         let _ = js_sys::Reflect::set(
             &output,
-            &JsValue::from_str("stdout"),
+            &JsValue::from_str("stdoutBytes"),
             &Uint8Array::from(stdout.as_slice()),
         );
         js_sys::Object::define_property(
             &output,
-            &JsValue::from_str("stdoutUtf8"),
+            &JsValue::from_str("stdout"),
             &lazily_decoded_string_property(stdout),
         );
         let _ = js_sys::Reflect::set(
             &output,
-            &JsValue::from_str("stderr"),
+            &JsValue::from_str("stderrBytes"),
             &Uint8Array::from(stderr.as_slice()),
         );
         js_sys::Object::define_property(
             &output,
-            &JsValue::from_str("stderrUtf8"),
+            &JsValue::from_str("stderr"),
             &lazily_decoded_string_property(stderr),
         );
 
@@ -196,13 +196,13 @@ export type Output = {
     /* Did the program exit successfully? */
     ok: boolean;
     /* The contents of the program's stdout stream. */
-    stdout: Uint8Array;
+    stdoutBytes: Uint8Array;
     /* The program's stdout stream, decoded as UTF-8. */
-    readonly stdoutUtf8: string;
+    readonly stdout: string;
     /* The contents of the program's stderr stream. */
-    stderr: Uint8Array;
+    stderrBytes: Uint8Array;
     /* The program's stderr stream, decoded as UTF-8. */
-    readonly stderrUtf8: string;
+    readonly stderr: string;
 }
 "#;
 

--- a/src/wasmer.rs
+++ b/src/wasmer.rs
@@ -33,8 +33,7 @@ use crate::{
 /// const { ok, code, stdout, stderr } = await instance.wait();
 ///
 /// if (ok) {
-///     const decoder = new TextDecoder("utf-8");
-///     console.log(`Version:`, decoder.decode(stdout).trim());
+///     console.log(`Version:`, stdout);
 /// } else {
 ///     throw new Error(`Python exited with ${code}: ${stderr}`);
 /// }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -25,7 +25,7 @@ describe("Wasmer.spawn", function () {
 
         expect(output.code).to.equal(0);
         expect(output.ok).to.be.true;
-        expect(decoder.decode(output.stdout)).to.equal("Hello, World!\n");
+        expect(output.stdout).to.equal("Hello, World!\n");
         expect(output.stderr.length).to.equal(0);
     });
 
@@ -119,7 +119,7 @@ describe("Wasmer.spawn", function () {
         const output = await instance.wait();
 
         expect(output.code).to.equal(42);
-        expect(decoder.decode(output.stderr)).to.equal("");
+        expect(output.stderr).to.equal("");
     });
 
     it("can communicate with a subprocess interactively", async () => {
@@ -153,7 +153,7 @@ describe("Wasmer.spawn", function () {
         expect(output.code).to.equal(0);
         // It looks like bash does its own TTY echoing, except it printed to
         // stderr instead of stdout like wasmer_wasix::os::Tty
-        expect(decoder.decode(output.stderr)).to.equal(
+        expect(output.stderr).to.equal(
             "bash-5.1# stdinout-loop\n\n\nFirst\n\n\n\nSecond\n\n\n\nbash-5.1# exit\n",
         );
     });
@@ -203,10 +203,10 @@ describe("Wasmer.spawn", function () {
 
         expect(output.ok).to.be.false;
         expect(output.code).to.equal(42);
-        expect(decoder.decode(output.stdout)).to.equal("");
+        expect(output.stdout).to.equal("");
         // Python prints the prompts to stderr, but our TTY handling prints
         // echoed characters to stdout
-        expect(decoder.decode(output.stderr)).to.equal(">>> >>> >>> >>> >>> ");
+        expect(output.stderr).to.equal(">>> >>> >>> >>> >>> ");
     });
 
     it("can see a mounted directory", async () => {
@@ -219,7 +219,7 @@ describe("Wasmer.spawn", function () {
         });
         const output = await instance.wait();
 
-        const stdout = decoder.decode(output.stdout);
+        const stdout = output.stdout;
         expect(stdout).to.contain("mounted");
         expect(output.ok).to.be.true;
     });
@@ -237,8 +237,8 @@ describe("Wasmer.spawn", function () {
         const output = await instance.wait();
 
         expect(output.ok).to.be.true;
-        expect(decoder.decode(output.stdout)).to.equal("file.txt\n");
-        expect(decoder.decode(output.stderr)).to.equal("");
+        expect(output.stdout).to.equal("file.txt\n");
+        expect(output.stderr).to.equal("");
     });
 
     it("can read from a mounted file", async () => {
@@ -252,7 +252,7 @@ describe("Wasmer.spawn", function () {
         });
         const output = await instance.wait();
 
-        const stdout = decoder.decode(output.stdout);
+        const stdout = output.stdout;
         expect(stdout).to.equal("Hello, World!");
         expect(output.ok).to.be.true;
     });
@@ -328,8 +328,8 @@ describe.skip("failing tty handling tests", function () {
         const { code, stdout, stderr } = await instance.wait();
 
         expect(code).to.equal(42);
-        expect(decoder.decode(stdout)).to.equal("bin\nlib\ntmp\n");
-        expect(decoder.decode(stderr)).to.equal("");
+        expect(stdout).to.equal("bin\nlib\ntmp\n");
+        expect(stderr).to.equal("");
     });
 
     it.skip("can communicate with a subprocess", async () => {

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -53,8 +53,8 @@ describe("run", function () {
 
         expect(output.ok).to.be.true;
         expect(output.code).to.equal(0);
-        expect(decoder.decode(output.stdout)).to.contain("Hello, World!");
-        expect(decoder.decode(output.stderr)).to.be.empty;
+        expect(output.stdout).to.contain("Hello, World!");
+        expect(output.stderr).to.be.empty;
     });
 
     it("can read directories", async () => {
@@ -80,8 +80,8 @@ describe("run", function () {
 
         expect(output.ok).to.be.true;
         expect(output.code).to.equal(0);
-        expect(decoder.decode(output.stdout)).to.equal(".\n..\nmount\n");
-        expect(decoder.decode(output.stderr)).to.be.empty;
+        expect(output.stdout).to.equal(".\n..\nmount\n");
+        expect(output.stderr).to.be.empty;
     });
 
     it("can read files", async () => {
@@ -107,8 +107,8 @@ describe("run", function () {
 
         expect(output.ok).to.be.true;
         expect(output.code).to.equal(0);
-        expect(decoder.decode(output.stdout)).to.equal("Hello, World!\n");
-        expect(decoder.decode(output.stderr)).to.be.empty;
+        expect(output.stdout).to.equal("Hello, World!\n");
+        expect(output.stderr).to.be.empty;
     });
 
     it("can read files mounted using DirectoryInit", async () => {
@@ -134,8 +134,8 @@ describe("run", function () {
 
         expect(output.ok).to.be.true;
         expect(output.code).to.equal(0);
-        expect(decoder.decode(output.stdout)).to.equal("Hello, World!\n");
-        expect(decoder.decode(output.stderr)).to.be.empty;
+        expect(output.stdout).to.equal("Hello, World!\n");
+        expect(output.stderr).to.be.empty;
     });
 
     it("can write files", async () => {


### PR DESCRIPTION
This PR improves the Output of `.wait()` by renaming the variables for convenience of usage:
* `stdout` -> `stdoutBytes`
* `stdoutUtf8` -> `stdout`
* `stderr` -> `stderrBytes`
* `stderrUtf8` -> `stderr`