### PR TITLE
Correct types field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/WasmerSDK.cjs",
   "module": "dist/WasmerSDK.js",
   "unpkg": "dist/WasmerSDK.umd.js",
-  "types": "dist/WasmerSDK.d.ts",
+  "types": "dist/lib.d.ts",
   "keywords": [
     "webassembly",
     "wasm",


### PR DESCRIPTION
There is no `WasmerSDK.d.ts` file in `dist`

![image](https://github.com/wasmerio/wasmer-js/assets/24491503/eaf57272-31ca-4026-a212-d49eeb264325)

![image](https://github.com/wasmerio/wasmer-js/assets/24491503/5aa6dce7-c0d4-4341-aeae-fbe88854c8dd)
