### PR TITLE
Fix mismatched stdin type

### DIFF
--- a/examples/wasmer.sh/package-lock.json
+++ b/examples/wasmer.sh/package-lock.json
@@ -19,24 +19,22 @@
     },
     "../..": {
       "name": "@wasmer/sdk",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
+        "@babel/preset-env": "^7.23.3",
         "@esm-bundle/chai": "^4.3.4-fix.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@rollup/plugin-typescript": "^11.1.5",
-        "@rollup/plugin-url": "^8.0.1",
+        "@rollup/plugin-wasm": "^6.2.2",
         "@web/dev-server-esbuild": "^1.0.1",
         "@web/test-runner": "^0.18.0",
         "prettier": "^3.1.0",
         "rimraf": "^5.0.5",
         "rollup": "^4.8.0",
+        "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-dts": "^6.1.0",
-        "rollup-plugin-node-polyfills": "^0.2.1",
-        "rollup-plugin-typescript2": "^0.36.0",
-        "ts-loader": "^9.2.6",
-        "tslib": "^2.3.1",
         "typedoc": "^0.25.4",
         "typescript": "^5.3.3"
       }

--- a/src/options.rs
+++ b/src/options.rs
@@ -29,7 +29,7 @@ type CommonOptions = {
     /** Environment variables to set. */
     env?: Record<string, string>;
     /** The standard input stream. */
-    stdin?: string | ArrayBuffer;
+    stdin?: string | Uint8Array;
     /**
      * Directories that should be mounted inside the WASIX instance.
      *


### PR DESCRIPTION
While troubleshooting some errors on @theduke's [simplimage](https://github.com/theduke/simplimage) demo, we found that the `stdin` field in `CommonOptions` was defined as `stdin?: string | ArrayBuffer` when the `StringOrBytes` type we use [expects `string | Uint8Array`](https://github.com/wasmerio/wasmer-js/blob/b4bb6028c83fabac2677b3cc4fd6c98c4732a338/src/utils.rs#L277-L287).