### PR TITLE
Change the default import to `WasmerSDKBundled.js` 

### DIFF
--- a/examples/markdown-editor-improved/index.ts
+++ b/examples/markdown-editor-improved/index.ts
@@ -1,4 +1,4 @@
-import { init, Wasmer, Command } from "@wasmer/sdk/dist/WasmerSDKBundled.js";
+import { init, Wasmer, Command } from "@wasmer/sdk";
 
 async function initialize() {
     await init();

--- a/examples/markdown-editor/index.ts
+++ b/examples/markdown-editor/index.ts
@@ -1,4 +1,4 @@
-import { init, runWasix } from "@wasmer/sdk/dist/WasmerSDKBundled.js";
+import { init, runWasix } from "@wasmer/sdk";
 import markdownRendererUrl from "./markdown-renderer/target/wasm32-wasi/release/markdown-renderer.wasm?url";
 
 async function initialize() {

--- a/examples/wasmer.sh/index.ts
+++ b/examples/wasmer.sh/index.ts
@@ -13,7 +13,7 @@ async function main() {
     // same chunk as @wasmer/sdk, each Web Worker will try to run this code and
     // crash.
     // See https://github.com/wasmerio/wasmer-js/issues/373
-    const { Wasmer, init, initializeLogger } = await import("@wasmer/sdk/dist/WasmerSDKBundled");
+    const { Wasmer, init, initializeLogger } = await import("@wasmer/sdk");
 
     await init();
     initializeLogger("debug");

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@wasmer/sdk",
   "version": "0.5.1",
-  "main": "dist/WasmerSDK.cjs",
-  "module": "dist/WasmerSDK.js",
-  "unpkg": "dist/WasmerSDK.umd.js",
-  "types": "dist/WasmerSDK.d.ts",
+  "main": "dist/WasmerSDKBundled.js",
+  "unpkg": "dist/WasmerSDKBundled.umd.js",
+  "module": "dist/WasmerSDKBundled.js",
+  "types": "dist/WasmerSDKBundled.d.ts",
   "keywords": [
     "webassembly",
     "wasm",

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -52,7 +52,6 @@ describe("Wasmer.spawn", function () {
 
         const output = await instance.wait();
 
-        console.log({...output});
         expect(output.ok).to.be.true;
         expect(output.code).to.equal(0);
         expect(output.stderr).to.equal("Hello\n\nWorld!\n\n");


### PR DESCRIPTION
Importing `@wasmer/sdk` will now pull in the version with `wasmer_js_bg.wasm` embedded as a base64 string, by default.

Fixes SDK-47.