### PR TITLE
Prevent Web Workers from crashing on startup when running with xterm.js

### DIFF
--- a/examples/wasmer.sh/index.ts
+++ b/examples/wasmer.sh/index.ts
@@ -1,12 +1,20 @@
 import "xterm/css/xterm.css";
 
-import { Wasmer, init, initializeLogger, Instance } from "@wasmer/sdk/dist/WasmerSDKBundled.js";
+import type { Instance } from "@wasmer/sdk";
 import { Terminal } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
 
 const encoder = new TextEncoder();
 
 async function main() {
+    // Note: We dynamically import the Wasmer SDK to make sure the bundler puts
+    // it in its own chunk. This works around an issue where just importing
+    // xterm.js runs top-level code which accesses the DOM, and if it's in the
+    // same chunk as @wasmer/sdk, each Web Worker will try to run this code and
+    // crash.
+    // See https://github.com/wasmerio/wasmer-js/issues/373
+    const { Wasmer, init, initializeLogger } = await import("@wasmer/sdk/dist/WasmerSDKBundled");
+
     await init();
     initializeLogger("debug");
 

--- a/examples/wasmer.sh/package-lock.json
+++ b/examples/wasmer.sh/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../..": {
       "name": "@wasmer/sdk",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.23.3",

--- a/examples/wasmer.sh/vite.config.js
+++ b/examples/wasmer.sh/vite.config.js
@@ -7,4 +7,9 @@ export default defineConfig({
             "Cross-Origin-Embedder-Policy": "require-corp",
         },
     },
+    build: {
+        modulePreload: {
+            polyfill: false,
+        },
+    },
 });


### PR DESCRIPTION
When we make a production build of `wasmer.sh` and run it with `static-web-server`, newly spawned Web Workers will crash when they import the Wasmer SDK because the bundle also includes `xterm.js` and importing `xterm.js` runs top-level code which tries to access the DOM.

My solution is to dynamically import `@wasmer/sdk`, which means `vite` will put it in a separate chunk.

Fixes #373.