### PR TITLE
Allow the scheduler to spawn as many Web Workers as it needs

### DIFF
--- a/src/js_runtime.rs
+++ b/src/js_runtime.rs
@@ -1,5 +1,4 @@
 use std::{
-    num::NonZeroUsize,
     ops::{Deref, DerefMut},
     sync::Arc,
 };
@@ -33,15 +32,7 @@ impl JsRuntime {
 impl JsRuntime {
     #[wasm_bindgen(constructor)]
     pub fn js_new(options: Option<RuntimeOptions>) -> Result<JsRuntime, Error> {
-        let pool_size = options.as_ref().and_then(|options| options.pool_size());
-
-        let pool = match pool_size {
-            Some(size) => {
-                let size = NonZeroUsize::new(size).unwrap_or(NonZeroUsize::MIN);
-                ThreadPool::new(size)
-            }
-            None => ThreadPool::new_with_max_threads()?,
-        };
+        let pool = ThreadPool::new();
 
         let registry = match options.as_ref().and_then(|opts| opts.registry()) {
             Some(registry_url) => registry_url.resolve(),
@@ -109,10 +100,6 @@ const RUNTIME_OPTIONS_TYPE_DECLARATION: &str = r#"
  */
 export type RuntimeOptions = {
     /**
-     * The number of worker threads to use.
-     */
-    poolSize?: number;
-    /**
      * The GraphQL endpoint for the Wasmer registry used when looking up
      * packages.
      *
@@ -136,9 +123,6 @@ export type RuntimeOptions = {
 extern "C" {
     #[wasm_bindgen(typescript_type = "RuntimeOptions")]
     pub type RuntimeOptions;
-
-    #[wasm_bindgen(method, getter, js_name = "poolSize")]
-    fn pool_size(this: &RuntimeOptions) -> Option<usize>;
 
     #[wasm_bindgen(method, getter)]
     fn registry(this: &RuntimeOptions) -> Option<MaybeRegistryUrl>;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -70,7 +70,7 @@ impl Runtime {
     }
 
     pub(crate) fn with_defaults() -> Result<Self, Error> {
-        let pool = ThreadPool::new_with_max_threads()?;
+        let pool = ThreadPool::new();
         let mut rt = Runtime::new(pool);
 
         rt.set_registry(crate::DEFAULT_REGISTRY, None)?;

--- a/src/tasks/post_message_payload.rs
+++ b/src/tasks/post_message_payload.rs
@@ -300,7 +300,7 @@ mod tests {
         let engine = wasmer::Engine::default();
         let module = wasmer::Module::new(&engine, wasm).unwrap();
         let flag = Arc::new(AtomicBool::new(false));
-        let pool = ThreadPool::new(NonZeroUsize::MAX);
+        let pool = ThreadPool::new();
         let runtime = Runtime::new(pool);
         let env = WasiEnvBuilder::new("program")
             .runtime(Arc::new(runtime))


### PR DESCRIPTION
This fixes #376 by removing the limit on the number of Web Workers a `Scheduler` is allowed to spawn.

Previously, when the `Scheduler` received a new task it would first look for an "idle" worker to give it to, otherwise it would spawn a new worker if there was capacity, otherwise if it had reached the maximum number of allowed workers it would fall back to sending the job to a worker that is already "busy" (i.e. running a blocking operation).

This removes the capacity limit so we'll always spawn a new worker when no idle workers are available. It means users of `@wasmer/sdk` are allowed to spawn an unbounded number of WASIX threads and each thread will be given CPU time by the OS. This PR doesn't introduce any sort of garbage collection mechanism though (e.g. kill a worker after being unused for 10 seconds), so once a worker has been spawned it will stay around until the scheduler itself (owned by the `Runtime`) is deleted.