### PR TITLE
Bump the `wasmer` dependency to pick up wasmerio/wasmer#4366

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,7 +2089,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "virtual-fs"
 version = "0.10.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "virtual-mio"
 version = "0.3.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2126,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "virtual-net"
 version = "0.6.1"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2213,7 +2213,7 @@ dependencies = [
 [[package]]
 name = "wai-bindgen-wasmer"
 version = "0.17.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -2558,7 +2558,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "backtrace",
  "cc",
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix"
 version = "0.17.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "wasmer-wasix-types"
 version = "0.17.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d04dcd11a7cd16cb0f005fcd75c4da99576ed9c6"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",

--- a/examples/wasmer.sh/package-lock.json
+++ b/examples/wasmer.sh/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../..": {
       "name": "@wasmer/sdk",
-      "version": "0.6.0-alpha",
+      "version": "0.6.0-beta2",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.23.3",


### PR DESCRIPTION
Before:

![image](https://github.com/wasmerio/wasmer-js/assets/17380079/6f99fec8-1b7d-4304-8d74-4b49bb1bfb8a)

After:

![2023-12-21_16-30](https://github.com/wasmerio/wasmer-js/assets/17380079/edfffc57-9cf3-43a8-b683-b3af2eb00eb3)


See also wasmerio/wasmer#4366, SDK-62.