### PR TITLE
Running `import asyncio` with `wasmer/python@3.12` in the browser deadlocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1991,6 +2006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,8 +2113,8 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "virtual-fs"
-version = "0.10.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "0.11.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2112,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "virtual-mio"
 version = "0.3.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2125,18 +2150,20 @@ dependencies = [
 
 [[package]]
 name = "virtual-net"
-version = "0.6.1"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "0.6.2"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "bincode",
+ "bytecheck",
  "bytes",
  "derivative",
  "futures-util",
  "libc",
  "pin-project-lite",
+ "rkyv",
  "serde",
  "thiserror",
  "tokio",
@@ -2212,8 +2239,8 @@ dependencies = [
 
 [[package]]
 name = "wai-bindgen-wasmer"
-version = "0.17.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "0.18.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -2418,8 +2445,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "4.2.5"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -2447,8 +2474,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "4.2.5"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2474,13 +2501,37 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "4.2.5"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "wasmer-journal"
+version = "0.1.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64",
+ "bincode",
+ "bytecheck",
+ "bytes",
+ "derivative",
+ "lz4_flex",
+ "num_enum",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "virtual-net",
+ "wasmer",
+ "wasmer-wasix-types",
 ]
 
 [[package]]
@@ -2540,8 +2591,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "4.2.5"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -2557,8 +2608,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "4.2.4"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "4.2.5"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "backtrace",
  "cc",
@@ -2585,12 +2636,14 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasix"
-version = "0.17.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "0.18.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "bincode",
+ "bytecheck",
  "bytes",
  "cfg-if",
  "chrono",
@@ -2606,10 +2659,13 @@ dependencies = [
  "lazy_static",
  "libc",
  "linked_hash_set",
+ "lz4_flex",
+ "num_enum",
  "once_cell",
  "petgraph",
  "pin-project",
  "rand",
+ "rkyv",
  "semver",
  "serde",
  "serde_cbor",
@@ -2617,6 +2673,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "sha2",
+ "shared-buffer",
  "tempfile",
  "term_size",
  "termios",
@@ -2633,18 +2690,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasmer",
+ "wasmer-journal",
  "wasmer-types",
  "wasmer-wasix-types",
  "web-sys",
  "webc",
  "weezl",
  "winapi",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "wasmer-wasix-types"
-version = "0.17.0"
-source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d2ac6c26c70714a2d6e88b6487878811b6e651e2"
+version = "0.18.0"
+source = "git+https://github.com/wasmerio/wasmer?branch=wasi-runner-mount-fs-instances#d37aa0d358158bb64b35e88ce62a657b839cb18b"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -2924,6 +2983,12 @@ checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53be06678ed9e83edb1745eb72efc0bbcd7b5c3c35711a860906aed827a13d61"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,15 +29,15 @@ tracing = { version = "0.1", features = ["log", "release_max_level_debug"] }
 tracing-futures = { version = "0.2" }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 url = "2.4.0"
-virtual-fs = { version = "0.10.0", default-features = false }
+virtual-fs = { version = "0.11.0", default-features = false }
 virtual-net = { version = "0.6.0", default-features = false, features = ["remote"] }
 wasm-bindgen = { version = "0.2" }
 wasm-bindgen-derive = "0.2.1"
 wasm-bindgen-downcast = "0.1"
 wasm-bindgen-futures = "0.4"
 wasm-bindgen-test = "0.3.37"
-wasmer = { version = "4.2.4", default-features = false, features = ["js", "js-default", "tracing", "wasm-types-polyfill", "enable-serde"] }
-wasmer-wasix = { version = "0.17", default-features = false, features = ["js", "js-default"] }
+wasmer = { version = "4.2.5", default-features = false, features = ["js", "js-default", "tracing", "wasm-types-polyfill", "enable-serde"] }
+wasmer-wasix = { version = "0.18", default-features = false, features = ["js", "js-default"] }
 webc = "5.3.0"
 
 [dependencies.web-sys]

--- a/examples/wasmer.sh/index.ts
+++ b/examples/wasmer.sh/index.ts
@@ -6,7 +6,12 @@ import { Terminal } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
 
 const encoder = new TextEncoder();
+const params = new URLSearchParams(window.location.search);
 
+const packageName = params.get("package") || "sharrattj/bash";
+const uses = params.getAll("use");
+const args = params.getAll("arg");
+const logFilter = params.get("log") || "warn";
 
 async function main() {
     // Note: We dynamically import the Wasmer SDK to make sure the bundler puts
@@ -18,7 +23,7 @@ async function main() {
     const { Wasmer, init, initializeLogger } = await import("@wasmer/sdk");
 
     await init(wasmerSDKUrl);
-    // initializeLogger("debug");
+    initializeLogger(logFilter);
 
     const term = new Terminal({ cursorBlink: true, convertEol: true });
     const fit = new FitAddon();
@@ -27,9 +32,9 @@ async function main() {
     fit.fit();
 
     term.writeln("Starting...");
-    const pkg = await Wasmer.fromRegistry("sharrattj/bash");
+    const pkg = await Wasmer.fromRegistry(packageName);
     term.reset();
-    const instance = await pkg.entrypoint!.run();
+    const instance = await pkg.entrypoint!.run({ args, uses });
     connectStreams(instance, term);
 }
 

--- a/src/tasks/post_message_payload.rs
+++ b/src/tasks/post_message_payload.rs
@@ -161,12 +161,9 @@ impl PostMessagePayload {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        num::NonZeroUsize,
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Arc,
-        },
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
     };
 
     use futures::channel::oneshot;
@@ -279,7 +276,7 @@ mod tests {
         let engine = wasmer::Engine::default();
         let module = wasmer::Module::new(&engine, wasm).unwrap();
         let msg = PostMessagePayload::Notification(Notification::CacheModule {
-            hash: ModuleHash::sha256(wasm),
+            hash: ModuleHash::hash(wasm),
             module: module.into(),
         });
 
@@ -288,7 +285,7 @@ mod tests {
 
         match round_tripped {
             PostMessagePayload::Notification(Notification::CacheModule { hash, module: _ }) => {
-                assert_eq!(hash, ModuleHash::sha256(wasm));
+                assert_eq!(hash, ModuleHash::hash(wasm));
             }
             _ => unreachable!(),
         };


### PR DESCRIPTION
The reason running `import asyncio` from Python causes the browser to lock up is because the `__asyncifiy_with_deep_sleep()` method blocking syscalls until a future resolves, but the `setTimeout()` future from `ThreadPool::sleep_now()` never gets a chance to mark itself as resolved because the JavaScript VM is currently blocked by the syscall.

This is very similar to the issue we had where `proc_exec()` would block while waiting for a HTTP request to finish (see https://github.com/wasmerio/wasmer/commit/293856f733fb49dfcf4cd189f29e986fd7cdfd69 from https://github.com/wasmerio/wasmer/pull/4192 for more). 

Fixes SDK-73.