### PR TITLE
Pass the import URL to the worker bootstrap script via the `init` message

### DIFF
--- a/src/tasks/worker.js
+++ b/src/tasks/worker.js
@@ -14,9 +14,9 @@ let handleMessage = async data => {
 
 globalThis.onmessage = async ev => {
     if (ev.data.type == "init") {
-        const { memory, module, id } = ev.data;
+        const { memory, module, id, import_url } = ev.data;
         const imported = await import(
-            new URL("$IMPORT_META_URL", self.location.origin)
+            new URL(import_url, self.location.origin)
         );
 
         // HACK: How we load our imports will change depending on how the code

--- a/tests/directory.test.ts
+++ b/tests/directory.test.ts
@@ -10,7 +10,7 @@ const initialized = (async () => {
 })();
 
 describe("In-Memory Directory", function () {
-    this.beforeAll(async () => await initialized);
+    this.timeout("60s").beforeAll(async () => await initialized);
 
     it("read empty dir", async () => {
         const dir = new Directory();


### PR DESCRIPTION
Fixes SDK-78.