### PR TITLE
fix: pass sdkUrl into init() in worker

### DIFF
--- a/src-js/worker.js
+++ b/src-js/worker.js
@@ -16,7 +16,7 @@ globalThis.onmessage = async ev => {
   if (ev.data.type == "init") {
     const { memory, module, id, sdkUrl } = ev.data;
     const { init, ThreadPoolWorker } = await import(sdkUrl);
-    await init({ module: module, memory: memory });
+    await init({ module: module, sdkUrl: sdkUrl, memory: memory });
 
     worker = new ThreadPoolWorker(id);
 


### PR DESCRIPTION
When a worker is calling `init()`, if the `sdkUrl` isn't passed in, the sdk url will be reset due to this code in `index.ts`:

```ts
if (initValue.sdkUrl) {
  setSDKUrl(initValue.sdkUrl.toString());
}
else {
  setSDKUrl(new URL("index.mjs", import.meta.url).toString());
}
```

It may cause some bugs since the default sdk url isn't available due to hashing in filename and etc.